### PR TITLE
Algol 60 to racket

### DIFF
--- a/collects/algol60/algol60.rkt
+++ b/collects/algol60/algol60.rkt
@@ -1,55 +1,56 @@
-#cs(module algol60 mzscheme
-     (require-for-syntax "parse.rkt"
-                         ;; Parses to generate an AST. Identifiers in the AST
-                         ;; are represented as syntax objects with source location.
+#lang racket
 
-                         "simplify.rkt"
-                         ;; Desugars the AST, transforming `for' to `if'+`goto',
-                         ;; and flattening `if' statements so they are always
-                         ;; of the for `if <exp> then goto <label> else goto <label>'
+;; Compiles a simplified AST to Scheme.
+(require "runtime.rkt" 
+         "prims.rkt"
+         
+         (for-syntax "parse.rkt"
+                     #|Parses to generate an AST. Identifiers in the AST
+                     ;; are represented as syntax objects with source location.|#
+                     
+                     "simplify.rkt"
+                     #|Desugars the AST, transforming `for' to `if'+`goto',
+                     and flattening `if' statements so they are always
+                     of the for `if <exp> then goto <label> else goto <label>' |#
+                     
+                     "compile.rkt" 
+                     racket/path))
 
-                         "compile.rkt"
-                         ;; Compiles a simplified AST to Scheme.
+(provide include-algol literal-algol)
 
-                         mzlib/file)
+#| By using #'here for the context of identifiers
+introduced by compilation, the identifiers can
+refer to runtime functions and primitives, as
+well as racket:|#
 
-     ;; By using #'here for the context of identifiers
-     ;; introduced by compilation, the identifiers can
-     ;; refer to runtime functions and primitives, as
-     ;; well as mzscheme:
-     (require "runtime.rkt" "prims.rkt")
-
-
-     (provide include-algol literal-algol)
-
-     (define-syntax (include-algol stx)
-       (syntax-case stx ()
-         [(_ str)
-          (string? (syntax-e (syntax str)))
-          
-	  (compile-simplified
-	   (simplify 
-	    (parse-a60-file 
-	     (normalize-path (syntax-e (syntax str))
-			     (or
-			      (current-load-relative-directory)
-			      (current-directory))))
-	    #'here)
-	   #'here)]))
+(define-syntax (include-algol stx)
+  (syntax-case stx ()
+    [(_ str)
+     (string? (syntax-e (syntax str)))
      
-     (define-syntax (literal-algol stx)
-       (syntax-case stx ()
-         [(_ strs ...)
-          (andmap (λ (x) (string? (syntax-e x))) 
-                  (syntax->list (syntax (strs ...))))
-          
-	  (compile-simplified
-	   (simplify 
-	    (parse-a60-port
-             (open-input-string 
-              (apply 
-               string-append
-               (map syntax-e (syntax->list #'(strs ...)))))
-             (syntax-source stx))
-	    #'here)
-	   #'here)])))
+     (compile-simplified
+      (simplify 
+       (parse-a60-file 
+        (normalize-path (syntax-e (syntax str))
+                        (or
+                         (current-load-relative-directory)
+                         (current-directory))))
+       #'here)
+      #'here)]))
+
+(define-syntax (literal-algol stx)
+  (syntax-case stx ()
+    [(_ strs ...)
+     (andmap (λ (x) (string? (syntax-e x))) 
+             (syntax->list (syntax (strs ...))))
+     
+     (compile-simplified
+      (simplify 
+       (parse-a60-port
+        (open-input-string 
+         (apply 
+          string-append
+          (map syntax-e (syntax->list #'(strs ...)))))
+        (syntax-source stx))
+       #'here)
+      #'here)]))

--- a/collects/algol60/base.rkt
+++ b/collects/algol60/base.rkt
@@ -1,10 +1,10 @@
-(module base mzscheme
-  (require "prims.rkt"
-           "runtime.rkt")
+#lang racket
+(require "prims.rkt"
+         "runtime.rkt")
 
-  (define base-importing-stx #'here)
+(define base-importing-stx #'here)
 
-  (provide (all-from mzscheme)
-           (all-from "prims.rkt")
-           (all-from "runtime.rkt")
-           base-importing-stx))
+(provide (all-from-out racket)
+         (all-from-out "prims.rkt")
+         (all-from-out "runtime.rkt")
+         base-importing-stx)

--- a/collects/algol60/bd-tool.rkt
+++ b/collects/algol60/bd-tool.rkt
@@ -1,35 +1,14 @@
 #lang s-exp framework/private/decode
 
-jVTJbtswEL3rK6YujJBFmbhGFyBAF/TUc69BAlDiWGJCkSpJ2/HfdyhKka04TXmwoZk3bxa+Y
-   c        E     8        /     t              l     q                 j
-9  \  B  \  \  \  \  \6V\  \  \  \  \OB\  \l9\  \  \  \  \YD\xq\jI\yh\  P
-F     j  a     3  U  E     5  Y     e     v     6  J  z  h     R        c
-EUb\rRF  \8K\4s\  \  D6J\U8v  \C9\AG\  \AGI  7AbB  \  \  \  \  S  xg5\awK
-4        p        u  S     E     Y     F  V  W     +  /     R  R        j
-G  \YO\b/\  lBK\cA\  \  \  \aQ\  \  \n8\  \  \  FVi\Ci\db\Z2\  \ID\i8\  I
-V        P  R     q  J  O        p        j     W           n        M  +
-Utd\S3\  \  \  \  \  \  \Kt\hg\YTqvo\D2\vl\Aw\pX\  3mM\VC\  \R1\b2\  S  1
-H        H     3     n        L                 r  T     Z        K  d  J
-L  \yscoZ\Qyjtb\DY\sp\Km\d+\  \  \  \bxacF\iU\  \  \  6  \vK\+q\  \  \  x
-e  n        y                 Y  2  O        0  e  A  r        +  W  k  U
-7  \  \  2  \  \gW\Zf\tK\KU\eH\  \  \  \Xa\  \  X  \  BEV\/u\  \  \  \  D
-m     q  M     Y                 q  9  V     b  D  h     8  5  P  8  d  0
-aCum5h\  \C+O0s\  6EZ\V5\6o\Rq\lp\  \  \  \C2Y  \  \6Xk  \  \  p  \  l  7
-W        s     I  H           o     g  y        V     N  A  i  r  y  /  W
-n  /uc\cT\  \  H  \  \m5F5lu  \  LGY\  \Fq\5c\IB\+Db  \  \  \  \  z  \  R
-G           A  C  u        i  H     3        H     m  3  0              w
-ohK\e3\HNHWR\  \  dFh\ka\  \  \wF\  \Mt\53\  z  \  \  \  \SZ\eh\arDF6\  2
-S              /        I  z        a     G     j     8        8        d
-I  \ht\DDxgusWt\kw\A+\  w  \c1\rN\re\  u  \5N\c/\M4r4v\Qm\y8\  \  \bH\EJY
-d                       u        h     X  /                 Y  d        s
-L  \wx\2Z\Jb\Yto26\Gl\10\p2U2x\  \  \h7\  \  \eV\k0Q8u\sB\  w  ttQ5Q2\  6
-n     5     N                 +     O     j  L     e     Y  f  Z        5
-ODhg  \  \  \  \x0HZM\8kJnas  \zN\H2\  \Qv6  \  \  \  \  \  \  Mly\2p\Nq1
-D     8  g     P           u  4     o     n     O  p  n     0           +
-F  \o3S  \0rh6C\  Ytf\su\  \  s  \  \O8\  \FP\72J  D03\8P\vt\AZ\vFula\  b
-2  d     6     P  S        F  o  M  Q     R     Z  0           w     Q  H
-o  \  \ah\  \  \  \  \/g\Yc\  \  e  \  \59\  \  \  \  mekqmzi  \  zHvD  5
-C  P        C  o  T           Q  u  H        2     q     8     f     x  K
-5  \XP\BSucV\  \  \+j\no\lC\P2\  \  \78\Lk\iw\da\kw\u6\  \  \PZ\ob\  q  s
-m              Z                 o                       5           7
-fBFSNtDWKqqHXiB7IqWDy0btkw9A+GJ7Z2L4h2Oy9YU9ipwxX+Bgp23X+OxIsnBVxmgMv/gI=
+lVXbjtowEH3nK6ZUaJ2qXljUi7RSL+pTn/sBlZx4SLzr2KntwPL3HccJEC4L6wfAM2cunjkz
+MIf/WuUQnCieMczLVg0/Cy28Hy6tUQGk62/BWp1NmMSVMmRq83zLcym2PyYATGMAxiQwj4U1
+0vPvUgQEVrTOoQm8F2d0CE4GwhD4G7AI47U1oQKZwddsLyTXUbTsbIawuSp5Xk96B+MkusNq
+8Yzc5k9YBEKHWjSzQUfavFVa8kZQOFZYrQmlrEmCqdCl1V8W0wymubx/asrpKLZWIWi8Ep4K
+8YEq0YFG5/XEdqh5LCH5Tg+FEgPfKBmqDD5lt8ErVGUVIj47tmCyOJcHl8UM8nqET24J78ml
+L4RGWNwvP3cf52DSiQ1P7oZkFrC45LAHvl8dAFICrHF2rSRCpNvPXfF55CJhO2msv6ob6/bs
+fIyKv9Ebw5dTDU9CnxB9P5tKeHyAtVXyRLw8Eae6Gdx0qfCVEzXOwLcNulnP6TQ8SdS/iylT
+oaMxip3J2xA6shnUw8NZB+fK+CBMUN3Q7PrQx97VKDnYXdmhVdLNiIEHNH3tsEspXTTQoiay
+xyGKRoDrcM1kvxmuAgf8IT2lEtqWZ8bk0pn+Fk2zhV/KhYrG8iP8iSP6bnq7B6LkydhczbNG
+70VJdOiZL9/soe/eTXkePfJNb7ytD/tOA2bD5IKv7Karz00+7lhunUR3WzVHIUI27gHzYUv7
+547GgdiE8kCdDE+pDEUlTIm8qGjf0z/Q/kmko81vfF9y0Fnvjm0qwh3vdLbbIxRjji+B4j2m
+r4NFAGeXQ+LSfw==

--- a/collects/algol60/compile.rkt
+++ b/collects/algol60/compile.rkt
@@ -1,536 +1,535 @@
-#cs(module compile mzscheme
-     (require "parse.rkt"
-              mzlib/match
-              mzlib/list)
+#lang racket
+(require "parse.rkt"
+         racket/match)
 
-     (provide compile-simplified)
+(provide compile-simplified)
 
-     ;; The compiler generates references to "prims.rkt" and
-     ;; "runtime.rkt" exports, as well as Racket forms
-     ;; and functions. The `ctx' argument provides
-     ;; an appropriate context for those bindings (in
-     ;; the form of a syntax object to use with d->s-o).
-     (define (compile-simplified stmt ctx)
-       (datum->syntax-object 
-	ctx
-	(parameterize ([current-compile-context ctx])
-	  (compile-a60 stmt 'void (empty-context) #t))))
+;; The compiler generates references to "prims.rkt" and
+;; "runtime.rkt" exports, as well as Racket forms
+;; and functions. The `ctx' argument provides
+;; an appropriate context for those bindings (in
+;; the form of a syntax object to use with d->s-o).
+(define (compile-simplified stmt ctx)
+  (datum->syntax 
+   ctx
+   (parameterize ([current-compile-context ctx])
+     (compile-a60 stmt 'void (empty-context) #t))))
 
-     (define current-compile-context (make-parameter #f))
-     
-     (define (compile-a60 stmt next-label context add-to-top-level?)
-       (match stmt
-         [($ a60:block decls statements)
-          (compile-block decls statements next-label context add-to-top-level?)]
-         [else
-          (compile-statement stmt next-label context)]))
-     
-     (define (compile-block decls statements next-label context add-to-top-level?)
-       (let* ([labels-with-numbers (map car statements)]
-              [labels (map (lambda (l)
-                             (if (stx-number? l)
-				 (datum->syntax-object
-				  l
-				  (string->symbol (format "~a" (syntax-e l)))
-				  l
-				  l)
-                                 l))
-                           labels-with-numbers)]
-              ;; Build environment by adding labels, then decls:
-              [context (foldl (lambda (decl context)
-                                (match decl
-                                  [($ a60:proc-decl result-type var arg-vars by-value-vars arg-specs body)
-                                   (add-procedure context var result-type arg-vars by-value-vars arg-specs)]
-                                  [($ a60:type-decl type ids)
-                                   (add-atoms context ids type)]
-                                  [($ a60:array-decl type arrays)
-                                   (add-arrays context 
-                                               (map car arrays) ; names
-                                               (map cdr arrays) ; dimensions
-                                               type)]
-                                  [($ a60:switch-decl name exprs)
-                                   (add-switch context name)]))
-                              (add-labels
-                               context
-                               labels)
-                              decls)])
-         ;; Generate bindings and initialization for all decls,
-         ;; plus all statements (thunked):
-	 (let ([bindings
-		(append
-		 (apply
-		  append
-                  ;; Decls:
-		  (map (lambda (decl)
-			 (match decl
-                           [($ a60:proc-decl result-type var arg-vars by-value-vars arg-specs body)
-                            (let ([code
-                                   `(lambda (kont . ,arg-vars)
-                                      ;; Extract by-value variables
-                                      (let ,(map (lambda (var)
-                                                   `[,var (get-value ,var)])
-                                                 by-value-vars)
-                                        ;; Set up the result variable and done continuation:
-                                        ,(let ([result-var (gensym 'prec-result)]
-                                               [done (gensym 'done)])
-                                           `(let* ([,result-var undefined]
-                                                   [,done (lambda () (kont ,result-var))])
-                                              ;; Include the compiled body:
-                                              ,(compile-a60 body done
-                                                            (add-settable-procedure
-                                                             (add-bindings
-                                                              context
-                                                              arg-vars
-                                                              by-value-vars
-                                                              arg-specs)
-                                                             var
-                                                             result-type
-                                                             result-var)
-                                                            #f)))))])
-                              (if add-to-top-level?
-                                  `([,var
-                                     (let ([tmp ,code])
-                                       (namespace-set-variable-value! ',var tmp)
-                                       tmp)])
-                                  `([,var
-                                     ,code])))]
-			   [($ a60:type-decl type ids)
-			    (map (lambda (id) `[,id undefined]) ids)]
-			   [($ a60:array-decl type arrays)
-			    (map (lambda (array) 
-				   `[,(car array) (make-array
-						   ,@(apply
-						      append
-						      (map
-						       (lambda (bp)
-							 (list
-							  (compile-expression (car bp) context 'num)
-							  (compile-expression (cdr bp) context 'num)))
-						       (cdr array))))])
-				 arrays)]
-			   [($ a60:switch-decl name exprs)
-			    `([,name (make-switch ,@(map (lambda (e) `(lambda () ,(compile-expression e context 'des)))
-							 exprs))])]
-			   [else (error "can't compile decl")]))
-		       decls))
-                 ;; Statements: most of the work is in `compile-statement', but
-                 ;;  we provide the continuation label:
-		 (cdr
-		  (foldr (lambda (stmt label next-label+compiled)
-			   (cons label
-				 (cons
-				  `[,label
-				    (lambda ()
-				      ,(compile-statement (cdr stmt) 
-							  (car next-label+compiled)
-							  context))]
-				  (cdr next-label+compiled))))
-			 (cons next-label null)
-			 statements
-			 labels)))])
-           ;; Check for duplicate bindings:
-	   (let ([dup (check-duplicate-identifier (filter identifier? (map car bindings)))])
-	     (when dup
-	       (raise-syntax-error
-		#f
-		"name defined twice"
-		dup)))
-           ;; Generate code; body of leterec jumps to the first statement label.
-	   `(letrec ,bindings 
-              (,(caar statements))))))
-     
-     (define (compile-statement statement next-label context)
-       (match statement
-         [($ a60:block decls statements)
-          (compile-block decls statements next-label context #f)]
-         [($ a60:branch test ($ a60:goto then) ($ a60:goto else))
-          `(if (check-boolean ,(compile-expression test context 'bool))
-               (goto ,(check-label then context))
-               (goto ,(check-label else context)))]
-         [($ a60:goto label)
-          (at (expression-location label)
-              `(goto ,(compile-expression label context 'des)))]
-         [($ a60:dummy)
-          `(,next-label)]
-         [($ a60:call proc args)
-          (at (expression-location proc)
-              `(,(compile-expression proc context 'func)
-                (lambda (val) 
-                  (,next-label))
-                ,@(map (lambda (arg) (compile-argument arg context))
-                       args)))]
-         [($ a60:assign vars val)
-          ;; >>>>>>>>>>>>>>> Start clean-up here <<<<<<<<<<<<<<<<<
-          ;; Lift out the spec-finding part, and use it to generate
-          ;; an expected type that is passed to `compile-expression':
-          `(begin
-             (let ([val ,(compile-expression val context 'numbool)])
-               ,@(map (lambda (avar)
-                        (let ([var (a60:variable-name avar)])
-                          (at var
-                              (cond
-                                [(null? (a60:variable-indices avar))
-                                 (cond
-                                   [(call-by-name-variable? var context)
-                                    => (lambda (spec)
-                                         `(set-target! ,var ',var (coerce ',(spec-coerce-target spec null) val)))]
-                                   [(procedure-result-variable? var context)
-                                    `(set! ,(procedure-result-variable-name var context) 
-                                           (coerce ',(spec-coerce-target (procedure-result-spec var context) null) val))]
-                                   [(or (settable-variable? var context)
-                                        (array-element? var context))
-                                    => (lambda (spec)
-                                         `(,(if (own-variable? var context) 'set-box! 'set!)
-                                           ,var
-                                           (coerce ',(spec-coerce-target spec null) val)))]
-                                   [else (raise-syntax-error #f "confused by assignment" (expression-location var))])]
-                                [else
-                                 (let ([spec (or (array-element? var context)
-                                                 (call-by-name-variable? var context))])
-                                   `(array-set! ,(compile-expression (make-a60:variable var null) context 'numbool)
-                                                (coerce ',(spec-coerce-target spec null) val)
-                                                ,@(map (lambda (e) (compile-expression e context 'num)) 
-                                                       (a60:variable-indices avar))))]))))
-                      vars))
-             (,next-label))]
-         [else (error "can't compile statement")]))
-     
-     (define (compile-expression expr context type)
-       (match expr
-         [(? (lambda (x) (and (syntax? x) (number? (syntax-e x)))) n) 
-	  (if (eq? type 'des)
-	      ;; Need a label:
-	      (check-label (datum->syntax-object expr
-						 (string->symbol (number->string (syntax-e expr)))
-						 expr
-						 expr)
-			   context)
-	      ;; Normal use of a number:
-	      (begin
-		(check-type 'num type expr) 
-		(as-builtin n)))]
-         [(? (lambda (x) (and (syntax? x) (boolean? (syntax-e x)))) n) (check-type 'bool type expr) (as-builtin n)]
-         [(? (lambda (x) (and (syntax? x) (string? (syntax-e x)))) n)  (check-type 'string type expr) (as-builtin n)]
-         [(? identifier? i) (compile-expression (make-a60:variable i null) context type)]
-         [(? symbol? i) ; either a generated label or 'val:
-	  (unless (eq? expr 'val)
-	    (check-type 'des type expr))
-	  (datum->syntax-object #f i)]
-         [($ a60:subscript array index)
-          ;; Maybe a switch index, or maybe an array reference
-	  (at array
-	      (cond
-	       [(array-element? array context)
-		`(array-ref ,array ,(compile-expression index context 'num))]
-	       [(switch-variable? array context)
-		`(switch-ref ,array ,(compile-expression index context 'num))]
-	       [else (raise-syntax-error
-		      #f
-		      "confused by variable"
-		      array)]))]
-         [($ a60:binary t argt op e1 e2)
-	  (check-type t type expr)
-          (at op
-              `(,(as-builtin op) ,(compile-expression e1 context argt) ,(compile-expression e2 context argt)))]
-         [($ a60:unary t argt op e1)
-	  (check-type t type expr)
-          (at op
-              `(,(as-builtin op) ,(compile-expression e1 context argt)))]
-         [($ a60:variable var subscripts)
-          (let ([sub (lambda (wrap v)
-                       (wrap
-                        (if (null? subscripts)
-                            v
-                            `(array-ref ,v ,@(map (lambda (e) (compile-expression e context 'num)) subscripts)))))])
-            (cond
-              [(call-by-name-variable? var context)
-               => (lambda (spec)
-                    (check-spec-type spec type var subscripts)
-                    (sub (lambda (val) `(coerce ',(spec-coerce-target spec subscripts) ,val)) `(get-value ,var)))]
-	      [(primitive-variable? var context)
-	       => (lambda (name)
-		    (sub values
-                         (datum->syntax-object
-			  (current-compile-context)
-			  name
-			  var
-			  var)))]
-              [(and (procedure-result-variable? var context)
-                    (not (eq? type 'func)))
-               (unless (null? subscripts)
-                 (raise-syntax-error "confused by subscripts" var))
-               (let ([spec (procedure-result-spec var context)])
-                 (check-spec-type spec type var null)
-                 (at var
-                     `(coerce
-                       ',(spec-coerce-target spec null)
-                       ,(procedure-result-variable-name var context))))]
-              [(or (procedure-result-variable? var context)
-                   (procedure-variable? var context)
-                   (label-variable? var context)
-                   (settable-variable? var context)
-                   (array-element? var context))
-               => (lambda (spec)
-                    (let ([spec (if (or (procedure-result-variable? var context)
-                                        (procedure-variable? var context)
-                                        (and (array-element? var context)
-                                             (null? subscripts)))
-                                    #f ;; need just the proc or array...
-                                    spec)])
-                      (check-spec-type spec type var subscripts)
-                      (let ([target (spec-coerce-target spec subscripts)])
-                        (sub (if target
-                                 (lambda (v) `(coerce ',target ,v))
-                                 values)
-                             (if (own-variable? var context)
-                                 `(unbox ,var)
-                                 var)))))]
-              [else (raise-syntax-error
-                     #f
-                     "confused by expression"
-                     (expression-location var))]))]
-                   
-         [($ a60:app func args)
-          (at (expression-location func)
-              `(,(compile-expression func context 'func)
-                values
-                ,@(map (lambda (e) (compile-argument e context))
-                       args)))]
-         [($ a60:if test then else)
-          `(if (check-boolean ,(compile-expression test context 'bool))
-	       ,(compile-expression then context type)
-	       ,(compile-expression else context type))]
-         [else (error 'compile-expression "can't compile expression ~a" expr)]))
-     
-     (define (expression-location expr)
-       (if (syntax? expr)
-           expr
-           (match expr
-             [($ a60:subscript array index) (expression-location array)]
-             [($ a60:binary type argtype op e1 e2) op]
-             [($ a60:unary type argtype op e1) op]
-             [($ a60:variable var subscripts) (expression-location var)]
-             [($ a60:app func args)
-              (expression-location func)]
-             [else #f])))
-     
-     (define (compile-argument arg context)
+(define current-compile-context (make-parameter #f))
+
+(define (compile-a60 stmt next-label context add-to-top-level?)
+  (match stmt
+    [(a60:block decls statements)
+     (compile-block decls statements next-label context add-to-top-level?)]
+    [else
+     (compile-statement stmt next-label context)]))
+
+(define (compile-block decls statements next-label context add-to-top-level?)
+  (let* ([labels-with-numbers (map car statements)]
+         [labels (map (lambda (l)
+                        (if (stx-number? l)
+                            (datum->syntax
+                             l
+                             (string->symbol (format "~a" (syntax-e l)))
+                             l
+                             l)
+                            l))
+                      labels-with-numbers)]
+         ;; Build environment by adding labels, then decls:
+         [context (foldl (lambda (decl context)
+                           (match decl
+                             [(a60:proc-decl result-type var arg-vars by-value-vars arg-specs body)
+                              (add-procedure context var result-type arg-vars by-value-vars arg-specs)]
+                             [(a60:type-decl type ids)
+                              (add-atoms context ids type)]
+                             [(a60:array-decl type arrays)
+                              (add-arrays context 
+                                          (map car arrays) ; names
+                                          (map cdr arrays) ; dimensions
+                                          type)]
+                             [(a60:switch-decl name exprs)
+                              (add-switch context name)]))
+                         (add-labels
+                          context
+                          labels)
+                         decls)])
+    ;; Generate bindings and initialization for all decls,
+    ;; plus all statements (thunked):
+    (let ([bindings
+           (append
+            (apply
+             append
+             ;; Decls:
+             (map (lambda (decl)
+                    (match decl
+                      [(a60:proc-decl result-type var arg-vars by-value-vars arg-specs body)
+                       (let ([code
+                              `(lambda (kont . ,arg-vars)
+                                 ;; Extract by-value variables
+                                 (let ,(map (lambda (var)
+                                              `[,var (get-value ,var)])
+                                            by-value-vars)
+                                   ;; Set up the result variable and done continuation:
+                                   ,(let ([result-var (gensym 'prec-result)]
+                                          [done (gensym 'done)])
+                                      `(let* ([,result-var undefined]
+                                              [,done (lambda () (kont ,result-var))])
+                                         ;; Include the compiled body:
+                                         ,(compile-a60 body done
+                                                       (add-settable-procedure
+                                                        (add-bindings
+                                                         context
+                                                         arg-vars
+                                                         by-value-vars
+                                                         arg-specs)
+                                                        var
+                                                        result-type
+                                                        result-var)
+                                                       #f)))))])
+                         (if add-to-top-level?
+                             `([,var
+                                (let ([tmp ,code])
+                                  (namespace-set-variable-value! ',var tmp)
+                                  tmp)])
+                             `([,var
+                                ,code])))]
+                      [(a60:type-decl type ids)
+                       (map (lambda (id) `[,id undefined]) ids)]
+                      [(a60:array-decl type arrays)
+                       (map (lambda (array) 
+                              `[,(car array) (make-array
+                                              ,@(apply
+                                                 append
+                                                 (map
+                                                  (lambda (bp)
+                                                    (list
+                                                     (compile-expression (car bp) context 'num)
+                                                     (compile-expression (cdr bp) context 'num)))
+                                                  (cdr array))))])
+                            arrays)]
+                      [(a60:switch-decl name exprs)
+                       `([,name (make-switch ,@(map (lambda (e) `(lambda () ,(compile-expression e context 'des)))
+                                                    exprs))])]
+                      [else (error "can't compile decl")]))
+                  decls))
+            ;; Statements: most of the work is in `compile-statement', but
+            ;;  we provide the continuation label:
+            (cdr
+             (foldr (lambda (stmt label next-label+compiled)
+                      (cons label
+                            (cons
+                             `[,label
+                               (lambda ()
+                                 ,(compile-statement (cdr stmt) 
+                                                     (car next-label+compiled)
+                                                     context))]
+                             (cdr next-label+compiled))))
+                    (cons next-label null)
+                    statements
+                    labels)))])
+      ;; Check for duplicate bindings:
+      (let ([dup (check-duplicate-identifier (filter identifier? (map car bindings)))])
+        (when dup
+          (raise-syntax-error
+           #f
+           "name defined twice"
+           dup)))
+      ;; Generate code; body of leterec jumps to the first statement label.
+      `(letrec ,bindings 
+         (,(caar statements))))))
+
+(define (compile-statement statement next-label context)
+  (match statement
+    [(a60:block decls statements)
+     (compile-block decls statements next-label context #f)]
+    [(a60:branch test (a60:goto then) (a60:goto else))
+     `(if (check-boolean ,(compile-expression test context 'bool))
+          (goto ,(check-label then context))
+          (goto ,(check-label else context)))]
+    [(a60:goto label)
+     (at (expression-location label)
+         `(goto ,(compile-expression label context 'des)))]
+    [(a60:dummy)
+     `(,next-label)]
+    [(a60:call proc args)
+     (at (expression-location proc)
+         `(,(compile-expression proc context 'func)
+           (lambda (val) 
+             (,next-label))
+           ,@(map (lambda (arg) (compile-argument arg context))
+                  args)))]
+    [(a60:assign vars val)
+     ;; >>>>>>>>>>>>>>> Start clean-up here <<<<<<<<<<<<<<<<<
+     ;; Lift out the spec-finding part, and use it to generate
+     ;; an expected type that is passed to `compile-expression':
+     `(begin
+        (let ([val ,(compile-expression val context 'numbool)])
+          ,@(map (lambda (avar)
+                   (let ([var (a60:variable-name avar)])
+                     (at var
+                         (cond
+                           [(null? (a60:variable-indices avar))
+                            (cond
+                              [(call-by-name-variable? var context)
+                               => (lambda (spec)
+                                    `(set-target! ,var ',var (coerce ',(spec-coerce-target spec null) val)))]
+                              [(procedure-result-variable? var context)
+                               `(set! ,(procedure-result-variable-name var context) 
+                                      (coerce ',(spec-coerce-target (procedure-result-spec var context) null) val))]
+                              [(or (settable-variable? var context)
+                                   (array-element? var context))
+                               => (lambda (spec)
+                                    `(,(if (own-variable? var context) 'set-box! 'set!)
+                                      ,var
+                                      (coerce ',(spec-coerce-target spec null) val)))]
+                              [else (raise-syntax-error #f "confused by assignment" (expression-location var))])]
+                           [else
+                            (let ([spec (or (array-element? var context)
+                                            (call-by-name-variable? var context))])
+                              `(array-set! ,(compile-expression (make-a60:variable var null) context 'numbool)
+                                           (coerce ',(spec-coerce-target spec null) val)
+                                           ,@(map (lambda (e) (compile-expression e context 'num)) 
+                                                  (a60:variable-indices avar))))]))))
+                 vars))
+        (,next-label))]
+    [else (error "can't compile statement")]))
+
+(define (compile-expression expr context type)
+  (match expr
+    [(? (lambda (x) (and (syntax? x) (number? (syntax-e x)))) n) 
+     (if (eq? type 'des)
+         ;; Need a label:
+         (check-label (datum->syntax expr
+                                            (string->symbol (number->string (syntax-e expr)))
+                                            expr
+                                            expr)
+                      context)
+         ;; Normal use of a number:
+         (begin
+           (check-type 'num type expr) 
+           (as-builtin n)))]
+    [(? (lambda (x) (and (syntax? x) (boolean? (syntax-e x)))) n) (check-type 'bool type expr) (as-builtin n)]
+    [(? (lambda (x) (and (syntax? x) (string? (syntax-e x)))) n)  (check-type 'string type expr) (as-builtin n)]
+    [(? identifier? i) (compile-expression (make-a60:variable i null) context type)]
+    [(? symbol? i) ; either a generated label or 'val:
+     (unless (eq? expr 'val)
+       (check-type 'des type expr))
+     (datum->syntax #f i)]
+    [(a60:subscript array index)
+     ;; Maybe a switch index, or maybe an array reference
+     (at array
+         (cond
+           [(array-element? array context)
+            `(array-ref ,array ,(compile-expression index context 'num))]
+           [(switch-variable? array context)
+            `(switch-ref ,array ,(compile-expression index context 'num))]
+           [else (raise-syntax-error
+                  #f
+                  "confused by variable"
+                  array)]))]
+    [(a60:binary t argt op e1 e2)
+     (check-type t type expr)
+     (at op
+         `(,(as-builtin op) ,(compile-expression e1 context argt) ,(compile-expression e2 context argt)))]
+    [(a60:unary t argt op e1)
+     (check-type t type expr)
+     (at op
+         `(,(as-builtin op) ,(compile-expression e1 context argt)))]
+    [(a60:variable var subscripts)
+     (let ([sub (lambda (wrap v)
+                  (wrap
+                   (if (null? subscripts)
+                       v
+                       `(array-ref ,v ,@(map (lambda (e) (compile-expression e context 'num)) subscripts)))))])
        (cond
-         [(or (and (a60:variable? arg)
-                   (not (let ([v  (a60:variable-name arg)])
-                          (or (procedure-variable? v context)
-                              (label-variable? v context)
-                              (primitive-variable? v context)))))
-              (a60:subscript? arg))
-          (let ([arg (if (a60:subscript? arg)
-                         (make-a60:variable (a60:subscript-array arg)
-                                            (list (a60:subscript-index arg)))
-                         arg)])
-            `(case-lambda
-              [() ,(compile-expression arg context 'any)]
-              [(val)  ,(compile-statement (make-a60:assign (list arg) 'val) 'void context)]))]
-         [(identifier? arg)
-          (compile-argument (make-a60:variable arg null) context)]
-         [else `(lambda () ,(compile-expression arg context 'any))]))
+         [(call-by-name-variable? var context)
+          => (lambda (spec)
+               (check-spec-type spec type var subscripts)
+               (sub (lambda (val) `(coerce ',(spec-coerce-target spec subscripts) ,val)) `(get-value ,var)))]
+         [(primitive-variable? var context)
+          => (lambda (name)
+               (sub values
+                    (datum->syntax
+                     (current-compile-context)
+                     name
+                     var
+                     var)))]
+         [(and (procedure-result-variable? var context)
+               (not (eq? type 'func)))
+          (unless (null? subscripts)
+            (raise-syntax-error "confused by subscripts" var))
+          (let ([spec (procedure-result-spec var context)])
+            (check-spec-type spec type var null)
+            (at var
+                `(coerce
+                  ',(spec-coerce-target spec null)
+                  ,(procedure-result-variable-name var context))))]
+         [(or (procedure-result-variable? var context)
+              (procedure-variable? var context)
+              (label-variable? var context)
+              (settable-variable? var context)
+              (array-element? var context))
+          => (lambda (spec)
+               (let ([spec (if (or (procedure-result-variable? var context)
+                                   (procedure-variable? var context)
+                                   (and (array-element? var context)
+                                        (null? subscripts)))
+                               #f ;; need just the proc or array...
+                               spec)])
+                 (check-spec-type spec type var subscripts)
+                 (let ([target (spec-coerce-target spec subscripts)])
+                   (sub (if target
+                            (lambda (v) `(coerce ',target ,v))
+                            values)
+                        (if (own-variable? var context)
+                            `(unbox ,var)
+                            var)))))]
+         [else (raise-syntax-error
+                #f
+                "confused by expression"
+                (expression-location var))]))]
+    
+    [(a60:app func args)
+     (at (expression-location func)
+         `(,(compile-expression func context 'func)
+           values
+           ,@(map (lambda (e) (compile-argument e context))
+                  args)))]
+    [(a60:if test then else)
+     `(if (check-boolean ,(compile-expression test context 'bool))
+          ,(compile-expression then context type)
+          ,(compile-expression else context type))]
+    [else (error 'compile-expression "can't compile expression ~a" expr)]))
 
-     (define (check-type got expected expr)
-       (or (eq? expected 'any)
-	   (case got
-	     [(num) (memq expected '(num numbool))]
-	     [(bool) (memq expected '(bool numbool))]
-	     [(des) (memq expected '(des))]
-	     [(func) (memq expected '(func))]
-	     [else #f])
-	   (raise-syntax-error #f
-			       (format "type mismatch (~a != ~a)" got expected)
-			       expr)))
-     
-     (define (check-spec-type spec type expr subscripts)
-       (let ([target (spec-coerce-target spec subscripts)])
-         (when target
-           (case (syntax-e target)
-             [(integer real) (check-type 'num type expr)]
-             [(boolean) (check-type 'bool type expr)]
-             [(procedure) (check-type 'func type expr)]))))
-       
+(define (expression-location expr)
+  (if (syntax? expr)
+      expr
+      (match expr
+        [(a60:subscript array index) (expression-location array)]
+        [(a60:binary type argtype op e1 e2) op]
+        [(a60:unary type argtype op e1) op]
+        [(a60:variable var subscripts) (expression-location var)]
+        [(a60:app func args)
+         (expression-location func)]
+        [else #f])))
 
-     (define (check-label l context)
-       (if (or (symbol? l)
-	       (label-variable? l context))
-	   l
-	   (raise-syntax-error
-	    #f
-	    "undefined label"
-	    l)))
-     
-     (define (at stx expr)
-       (if (syntax? stx)
-           (datum->syntax-object (current-compile-context) expr stx)
-           expr))
+(define (compile-argument arg context)
+  (cond
+    [(or (and (a60:variable? arg)
+              (not (let ([v  (a60:variable-name arg)])
+                     (or (procedure-variable? v context)
+                         (label-variable? v context)
+                         (primitive-variable? v context)))))
+         (a60:subscript? arg))
+     (let ([arg (if (a60:subscript? arg)
+                    (make-a60:variable (a60:subscript-array arg)
+                                       (list (a60:subscript-index arg)))
+                    arg)])
+       `(case-lambda
+          [() ,(compile-expression arg context 'any)]
+          [(val)  ,(compile-statement (make-a60:assign (list arg) 'val) 'void context)]))]
+    [(identifier? arg)
+     (compile-argument (make-a60:variable arg null) context)]
+    [else `(lambda () ,(compile-expression arg context 'any))]))
 
-     (define (as-builtin stx)
-       ;; Preserve source loc, but change to reference to
-       ;; a builtin operation by changing the context:
-       (datum->syntax-object
-	(current-compile-context)
-	(syntax-e stx)
-	stx
-	stx))
+(define (check-type got expected expr)
+  (or (eq? expected 'any)
+      (case got
+        [(num) (memq expected '(num numbool))]
+        [(bool) (memq expected '(bool numbool))]
+        [(des) (memq expected '(des))]
+        [(func) (memq expected '(func))]
+        [else #f])
+      (raise-syntax-error #f
+                          (format "type mismatch (~a != ~a)" got expected)
+                          expr)))
 
-     ;; --------------------
-     
-     (define (empty-context)
-       `(((sign prim sign)
-	  (entier prim entier)
+(define (check-spec-type spec type expr subscripts)
+  (let ([target (spec-coerce-target spec subscripts)])
+    (when target
+      (case (syntax-e target)
+        [(integer real) (check-type 'num type expr)]
+        [(boolean) (check-type 'bool type expr)]
+        [(procedure) (check-type 'func type expr)]))))
 
-	  (sin prim a60:sin)
-	  (cos prim a60:cos)
-	  (acrtan prim a60:arctan)
-	  (sqrt prim a60:sqrt)
-	  (abs prim a60:abs)
-	  (ln prim a60:ln)
-	  (exp prim a60:exp)
 
-	  (prints prim prints)
-	  (printn prim printn)
-	  (printsln prim printsln)
-	  (printnln prim printnln))))
-     
-     (define (add-labels context l)
-       (cons (map (lambda (lbl) (cons (if (symbol? lbl)
-                                          (datum->syntax-object #f lbl)
-                                          lbl)
-                                      'label)) l)
-             context))
-     
-     (define (add-procedure context var result-type arg-vars by-value-vars arg-specs)
-       (cons (list (cons var 'procedure))
-             context))
-     
-     (define (add-settable-procedure context var result-type result-var)
-       (cons (list (cons var `(settable-procedure ,result-var ,result-type)))
-             context))
-     
-     (define (add-atoms context ids type)
-       (cons (map (lambda (id) (cons id type)) ids)
-             context))
+(define (check-label l context)
+  (if (or (symbol? l)
+          (label-variable? l context))
+      l
+      (raise-syntax-error
+       #f
+       "undefined label"
+       l)))
 
-     (define (add-arrays context names dimensionses type)
-       (cons (map (lambda (name dimensions)
-                    (cons name `(array ,type ,(length dimensions))))
-                  names dimensionses)
-             context))
+(define (at stx expr)
+  (if (syntax? stx)
+      (datum->syntax (current-compile-context) expr stx)
+      expr))
 
-     (define (add-switch context name)
-       (cons (list (cons name 'switch))
-             context))
-     
-     (define (add-bindings context arg-vars by-value-vars arg-specs)
-       (cons (map (lambda (var)
-                    (let ([spec (or (ormap (lambda (spec)
-                                             (and (ormap (lambda (x) (bound-identifier=? var x))
-                                                         (cdr spec))
-                                                  (car spec)))
-                                           arg-specs)
-                                    #'unknown)])
-                      (cons var
-                            (if (ormap (lambda (x) (bound-identifier=? var x)) by-value-vars)
-                                spec
-                                (list 'by-name spec)))))
-                  arg-vars)
-             context))
-     
-     ;; var-binding : syntax context -> symbol
-     ;; returns an identifier indicating where the var is
-     ;; bound, or 'free if it isn't. The compiler inserts
-     ;; top-level procedure definitions into the namespace; if 
-     ;; the variable is bound there, it is a procedure.
-     (define (var-binding var context)
-       (cond
-         [(null? context)
-          (let/ec k
-            (namespace-variable-value (syntax-e var)
-                                      #t 
-                                      (lambda () (k 'free)))
-            'procedure)]
-         [else
-          (let ([m (var-in-rib var (car context))])
-            (or m (var-binding var (cdr context))))]))
-     
-     (define (var-in-rib var rib)
-       (ormap (lambda (b)
-                (if (symbol? (car b))
-                    ;; primitives:
-                    (and (eq? (syntax-e var) (car b))
-                         (cdr b))
-                    ;; everything else:
-                    (and (bound-identifier=? var (car b))
-                         (cdr b))))
-              rib))
-     
-     (define (primitive-variable? var context)
-       (let ([v (var-binding var context)])
-	 (and (pair? v)
-	      (eq? (car v) 'prim)
-	      (cadr v))))
+(define (as-builtin stx)
+  ;; Preserve source loc, but change to reference to
+  ;; a builtin operation by changing the context:
+  (datum->syntax
+   (current-compile-context)
+   (syntax-e stx)
+   stx
+   stx))
 
-     (define (call-by-name-variable? var context)
-       (let ([v (var-binding var context)])
-         (and (pair? v)
-              (eq? (car v) 'by-name)
-              (cadr v))))
+;; --------------------
 
-     (define (procedure-variable? var context)
-       (let ([v (var-binding var context)])
-         (eq? v 'procedure)))
-
-     (define (procedure-result-variable? var context)
-       (let ([v (var-binding var context)])
-         (and (pair? v)
-              (eq? (car v) 'settable-procedure)
-              (cdr v))))
+(define (empty-context)
+  `(((sign prim sign)
+     (entier prim entier)
      
-     (define (procedure-result-variable-name var context)
-       (let ([v (procedure-result-variable? var context)])
-         (car v)))
-
-     (define (procedure-result-spec var context)
-       (let ([v (procedure-result-variable? var context)])
-         (cadr v)))
-
-     (define (label-variable? var context)
-       (let ([v (var-binding var context)])
-         (eq? v 'label)))
-         
-     (define (switch-variable? var context)
-       (let ([v (var-binding var context)])
-         (eq? v 'switch)))
-         
-     (define (settable-variable? var context)
-       (let ([v (var-binding var context)])
-         (or (box? v)
-             (and (syntax? v)
-                  (memq (syntax-e v) '(integer real boolean))
-                  v))))
+     (sin prim a60:sin)
+     (cos prim a60:cos)
+     (acrtan prim a60:arctan)
+     (sqrt prim a60:sqrt)
+     (abs prim a60:abs)
+     (ln prim a60:ln)
+     (exp prim a60:exp)
      
-     (define (own-variable? var context)
-       (let ([v (var-binding var context)])
-         (box? v)))
+     (prints prim prints)
+     (printn prim printn)
+     (printsln prim printsln)
+     (printnln prim printnln))))
 
-     (define (array-element? var context)
-       (let ([v (var-binding var context)])
-         (and (pair? v)
-              (eq? (car v) 'array)
-              (or (cadr v)
-                  #'unknown))))
-     
-     (define (spec-coerce-target spec subscripts)
-       (cond
-         [(and (syntax? spec) (memq (syntax-e spec) '(string label switch real integer boolean unknown))) spec]
-         [(and (syntax? spec) (memq (syntax-e spec) '(unknown))) #f]
-         [(or (not spec) (not (pair? spec))) #f]
-         [(eq? (car spec) 'array) (if (null? subscripts) #'array (cadr spec))]
-         [(eq? (car spec) 'procedure) #'procedure]
-         [else #f]))
-     
-     (define (stx-number? a) (and (syntax? a) (number? (syntax-e a)))))
+(define (add-labels context l)
+  (cons (map (lambda (lbl) (cons (if (symbol? lbl)
+                                     (datum->syntax #f lbl)
+                                     lbl)
+                                 'label)) l)
+        context))
+
+(define (add-procedure context var result-type arg-vars by-value-vars arg-specs)
+  (cons (list (cons var 'procedure))
+        context))
+
+(define (add-settable-procedure context var result-type result-var)
+  (cons (list (cons var `(settable-procedure ,result-var ,result-type)))
+        context))
+
+(define (add-atoms context ids type)
+  (cons (map (lambda (id) (cons id type)) ids)
+        context))
+
+(define (add-arrays context names dimensionses type)
+  (cons (map (lambda (name dimensions)
+               (cons name `(array ,type ,(length dimensions))))
+             names dimensionses)
+        context))
+
+(define (add-switch context name)
+  (cons (list (cons name 'switch))
+        context))
+
+(define (add-bindings context arg-vars by-value-vars arg-specs)
+  (cons (map (lambda (var)
+               (let ([spec (or (ormap (lambda (spec)
+                                        (and (ormap (lambda (x) (bound-identifier=? var x))
+                                                    (cdr spec))
+                                             (car spec)))
+                                      arg-specs)
+                               #'unknown)])
+                 (cons var
+                       (if (ormap (lambda (x) (bound-identifier=? var x)) by-value-vars)
+                           spec
+                           (list 'by-name spec)))))
+             arg-vars)
+        context))
+
+;; var-binding : syntax context -> symbol
+;; returns an identifier indicating where the var is
+;; bound, or 'free if it isn't. The compiler inserts
+;; top-level procedure definitions into the namespace; if 
+;; the variable is bound there, it is a procedure.
+(define (var-binding var context)
+  (cond
+    [(null? context)
+     (let/ec k
+       (namespace-variable-value (syntax-e var)
+                                 #t 
+                                 (lambda () (k 'free)))
+       'procedure)]
+    [else
+     (let ([m (var-in-rib var (car context))])
+       (or m (var-binding var (cdr context))))]))
+
+(define (var-in-rib var rib)
+  (ormap (lambda (b)
+           (if (symbol? (car b))
+               ;; primitives:
+               (and (eq? (syntax-e var) (car b))
+                    (cdr b))
+               ;; everything else:
+               (and (bound-identifier=? var (car b))
+                    (cdr b))))
+         rib))
+
+(define (primitive-variable? var context)
+  (let ([v (var-binding var context)])
+    (and (pair? v)
+         (eq? (car v) 'prim)
+         (cadr v))))
+
+(define (call-by-name-variable? var context)
+  (let ([v (var-binding var context)])
+    (and (pair? v)
+         (eq? (car v) 'by-name)
+         (cadr v))))
+
+(define (procedure-variable? var context)
+  (let ([v (var-binding var context)])
+    (eq? v 'procedure)))
+
+(define (procedure-result-variable? var context)
+  (let ([v (var-binding var context)])
+    (and (pair? v)
+         (eq? (car v) 'settable-procedure)
+         (cdr v))))
+
+(define (procedure-result-variable-name var context)
+  (let ([v (procedure-result-variable? var context)])
+    (car v)))
+
+(define (procedure-result-spec var context)
+  (let ([v (procedure-result-variable? var context)])
+    (cadr v)))
+
+(define (label-variable? var context)
+  (let ([v (var-binding var context)])
+    (eq? v 'label)))
+
+(define (switch-variable? var context)
+  (let ([v (var-binding var context)])
+    (eq? v 'switch)))
+
+(define (settable-variable? var context)
+  (let ([v (var-binding var context)])
+    (or (box? v)
+        (and (syntax? v)
+             (memq (syntax-e v) '(integer real boolean))
+             v))))
+
+(define (own-variable? var context)
+  (let ([v (var-binding var context)])
+    (box? v)))
+
+(define (array-element? var context)
+  (let ([v (var-binding var context)])
+    (and (pair? v)
+         (eq? (car v) 'array)
+         (or (cadr v)
+             #'unknown))))
+
+(define (spec-coerce-target spec subscripts)
+  (cond
+    [(and (syntax? spec) (memq (syntax-e spec) '(string label switch real integer boolean unknown))) spec]
+    [(and (syntax? spec) (memq (syntax-e spec) '(unknown))) #f]
+    [(or (not spec) (not (pair? spec))) #f]
+    [(eq? (car spec) 'array) (if (null? subscripts) #'array (cadr spec))]
+    [(eq? (car spec) 'procedure) #'procedure]
+    [else #f]))
+
+(define (stx-number? a) (and (syntax? a) (number? (syntax-e a))))

--- a/collects/algol60/info.rkt
+++ b/collects/algol60/info.rkt
@@ -1,5 +1,7 @@
 #lang setup/infotab
 
-(define tools '(("tool.rkt")))
-(define tool-names '("Algol 60"))
+(define drracket-name "Algol 60")
+(define drracket-tools '(("tool.rkt")))
+(define drracket-tool-names '("Algol 60"))
+
 (define scribblings '(("algol60.scrbl" () (experimental 40))))

--- a/collects/algol60/lang/reader.rkt
+++ b/collects/algol60/lang/reader.rkt
@@ -19,7 +19,7 @@ algol60/lang/algol60
          "../compile.rkt"
          ;; Compiles a simplified AST to Scheme.
 
-         mzlib/file
+         racket/file
          syntax/strip-context)
 
 

--- a/collects/algol60/parse.rkt
+++ b/collects/algol60/parse.rkt
@@ -1,413 +1,413 @@
-#cs(module parse mzscheme
-     (require parser-tools/lex
-              (prefix : parser-tools/lex-sre)
-              "cfg-parser.rkt"
-              parser-tools/yacc
-              syntax/readerr
-              "prims.rkt")
+#lang racket
+(require parser-tools/lex
+         (prefix-in : parser-tools/lex-sre)
+         "cfg-parser.rkt"
+         parser-tools/yacc
+         syntax/readerr
+         "prims.rkt")
 
-     (define-lex-abbrevs [lex:letter (:or (:/ #\a #\z) (:/ #\A #\Z))]
-                         [lex:digit (:/ #\0 #\9)]
-                         [lex:whitespace (:or #\newline #\return #\tab #\space #\vtab)]
-                         [lex:comment (:: (:* lex:whitespace) "comment" (:* (:~ #\;)) #\;)])
-     
-     (define-tokens non-terminals (<logical-value> 
-                                   <type> <identifier> 
-                                   <unsigned-integer> <unsigned-float> <string>
-                                   
-                                   GOTO IF THEN ELSE FOR DO STEP UNTIL WHILE
-                                   OWN ARRAY STRING PROCEDURE SWITCH LABEL VALUE
-                                   BEGIN END
-                                   POWER PLUS MINUS TIMES SLASH DIVIDE
-                                   LESS LESS-OR-EQUAL EQUAL GREATER-OR-EQUAL GREATER NOT-EQUAL ASSIGN
-                                   NEGATE AND OR IMPLIES EQUIV
-                                   COMMA COLON SEMICOLON
-                                   OPEN CLOSE OPENSQ CLOSESQ
-                                   EOF
-                                   UNPARSEABLE))
-     
-     (define stx-for-original-property (read-syntax #f (open-input-string "original")))
-     
-     (define-syntax (token stx)
-       (syntax-case stx ()
-         [(_ name val)
-          (identifier? (syntax name))
-          (let ([name (syntax name)])
-            (with-syntax ([token-name (datum->syntax-object
-                                       name
-                                       (string->symbol
-                                        (format "token-~a" (syntax-e name))))]
-                          [source-name (datum->syntax-object name 'source-name)]
-                          [start-pos (datum->syntax-object name 'start-pos)]
-                          [end-pos (datum->syntax-object name 'end-pos)])
-              (syntax 
-	       (token-name 
-		(datum->syntax-object #f val
-				      (list
-				       source-name
-				       (position-line start-pos)
-				       (position-col start-pos)
-				       (position-offset start-pos)
-				       (- (position-offset end-pos)
-					  (position-offset start-pos)))
-				      stx-for-original-property)))))]))
-     (define-syntax (ttoken stx)
-       (syntax-case stx ()
-         [(_ name)
-          (identifier? (syntax name))
-          (syntax (token name 'name))]))
-     
-     (define (lex source-name)
-       (lexer
-        [(:+ lex:whitespace) (void)]
-        ["true" (token <logical-value> #t)]
-        ["false" (token <logical-value> #f)]
-        ["real" (token <type> 'real)]
-        ["integer" (token <type> 'integer)]
-        ["Boolean" (token <type> 'boolean)]
-        ["goto" (ttoken GOTO)]
-        ["if" (ttoken IF)]
-        ["then" (ttoken THEN)]
-        ["else" (ttoken ELSE)]
-        ["for" (ttoken FOR)]
-        ["do" (ttoken DO)]
-        ["step" (ttoken STEP)]
-        ["until" (ttoken UNTIL)]
-        ["while" (ttoken WHILE)]
-        ["own" (ttoken OWN)]
-        ["array" (ttoken ARRAY)]
-        ["string" (ttoken STRING)]
-        ["procedure" (ttoken PROCEDURE)]
-        ["switch" (ttoken SWITCH)]
-        ["label" (ttoken LABEL)]
-        ["value" (ttoken VALUE)]
-        [(:: "begin" lex:comment) (ttoken BEGIN)]
-        ["begin" (ttoken BEGIN)]
-        [(:: "end" lex:comment) (ttoken BEGIN)]
-        ["end" (ttoken END)]
-        ["^" (token POWER 'expt)]
-        ["+" (token PLUS '+)]
-        ["-" (token MINUS '-)]
-        ["*" (token TIMES '*)]
-        ["/" (token SLASH '/)]
-        ["div" (token DIVIDE 'quotient)]
-        ["<" (token LESS '<)]
-        ["<=" (token LESS-OR-EQUAL '<=)]
-        ["=" (token EQUAL '=)]
-        [">" (token GREATER '>)]
-        [">=" (token GREATER-OR-EQUAL '>=)]
-        ["!=" (token NOT-EQUAL '!=)]
-        ["!" (token NEGATE '!)]
-        ["&" (token AND '&)]
-        ["|" (token OR '\|)]
-        ["=>" (token IMPLIES '==>)]
-        ["==" (token EQUIV '==)]
-        [":=" (ttoken ASSIGN)]
-        ["," (ttoken COMMA)]
-        [":" (ttoken COLON)]
-        [(:: ";" lex:comment) (ttoken SEMICOLON)]
-        [";" (ttoken SEMICOLON)]
-        ["(" (ttoken OPEN)]
-        [")" (ttoken CLOSE)]
-        ["[" (ttoken OPENSQ)]
-        ["]" (ttoken CLOSESQ)]
-        [(:: lex:letter (:* (:or lex:letter lex:digit))) (token <identifier> (string->symbol lexeme))]
-        [(:+ lex:digit) (token <unsigned-integer> (string->number lexeme))]
-        [(:or (:: (:+ lex:digit) #\. (:* lex:digit))
-              (:: (:* lex:digit) #\. (:+ lex:digit))) (token <unsigned-float> (string->number lexeme))]
-        [(:: #\` (:* (:~ #\' #\`)) #\') (let ([s lexeme])
-                                          (token <string> (substring s 1 (sub1 (string-length s)))))]
-        [(eof) (ttoken EOF)]
-        [any-char (token UNPARSEABLE (string->symbol lexeme))]))
-     
-     (define parse
-       (cfg-parser
-        (tokens non-terminals)
-        (start <program>)
-        (end EOF)
-        (error (lambda (_ name stx start end) 
-                 (raise-read-error (format "parse error near ~a" name)
-				   (syntax-source stx)
-				   (syntax-line stx)
-				   (syntax-column stx)
-				   (syntax-position stx)
-				   (syntax-span stx))))
-        (suppress)
-        (grammar 
-         ;; ==================== Expressions ====================
-         (<expression> [(<arithmetic-expression>) $1]
-                       [(<Boolean-expression>) $1]
-                       [(<designational-expression>) $1])
-         ;; -------------------- Numbers --------------------
-         (<arithmetic-expression> [(<simple-arithmetic-expression>) $1]
-                                  [(IF <Boolean-expression> 
-                                       THEN <simple-arithmetic-expression> 
-                                       ELSE <arithmetic-expression>)
-                                   (make-a60:if $2 $4 $6)])
-         (<simple-arithmetic-expression> [(<term>) $1]
-                                         [(<adding-operator> <term>) (make-a60:unary 'num 'num $1 $2)]
-                                         [(<simple-arithmetic-expression> <adding-operator> <term>) 
-                                          (make-a60:binary 'num 'num $2 $1 $3)])
-         (<term> [(<factor>) $1]
-                 [(<term> <multiplying-operator> <factor>) (make-a60:binary 'num 'num $2 $1 $3)])
-         (<factor> [(<primary>) $1]
-                   [(<factor> POWER <primary>) (make-a60:binary 'num 'num $2 $1 $3)])
-         (<adding-operator> [(PLUS) $1]
-                            [(MINUS) $1])
-         (<multiplying-operator> [(TIMES) $1]
-                                 [(SLASH) $1]
-                                 [(DIVIDE) $1])
-         (<primary> [(<unsigned-integer>) $1]
-                    [(<unsigned-float>) $1]
-                    [(<variable>) $1]
-                    [(<function-designator>) $1]
-                    [(OPEN <arithmetic-expression> CLOSE) $2])
-         ;; -------------------- Booleans --------------------
-         (<relational-operator> [(LESS) $1]
-                                [(LESS-OR-EQUAL) $1]
-                                [(EQUAL) $1]
-                                [(GREATER-OR-EQUAL) $1]
-                                [(GREATER) $1]
-                                [(NOT-EQUAL) $1])
-         (<relation> [(<simple-arithmetic-expression> <relational-operator> <simple-arithmetic-expression>)
-                      (make-a60:binary 'bool 'num $2 $1 $3)])
-         (<Boolean-primary> [(<logical-value>) $1]
-                            [(<variable>) $1]
-                            [(<function-designator>) $1]
-                            [(<relation>) $1]
-                            [(OPEN <Boolean-expression> CLOSE) $2])
-         (<Boolean-secondary> [(<Boolean-primary>) $1]
-                              [(NEGATE <Boolean-primary>) (make-a60:unary 'bool 'bool $1 $2)])
-         (<Boolean-factor> [(<Boolean-secondary>) $1]
-                           [(<Boolean-factor> AND <Boolean-secondary>) (make-a60:binary 'bool 'bool $2 $1 $3)])
-         (<Boolean-term> [(<Boolean-factor>) $1]
-                         [(<Boolean-term> OR <Boolean-factor>)  (make-a60:binary 'bool 'bool $2 $1 $3)])
-         
-         (<implication> [(<Boolean-term>) $1]
-                        [(<implication> IMPLIES <Boolean-term>) (make-a60:binary 'bool 'bool $2 $1 $3)])
-         (<simple-Boolean> [(<implication>) $1]
-                           [(<simple-Boolean> EQUIV <implication>) (make-a60:binary 'bool 'bool $2 $1 $3)])
-         (<Boolean-expression> [(<simple-Boolean>) $1]
-                               [(IF <Boolean-expression> 
-                                    THEN <simple-Boolean> 
-                                    ELSE <Boolean-expression>)
-				(make-a60:if $2 $4 $6)])
-         ;; -------------------- Designationals --------------------
-         (<label> [(<identifier>) $1]
-                  [(<unsigned-integer>) $1])
-         (<switch-identifier> [(<identifier>) $1])
-         (<switch-designator> [(<switch-identifier> OPENSQ <arithmetic-expression> CLOSESQ)
-                               (make-a60:subscript $1 $3)])
-         (<simple-designational-expression> [(<label>) $1]
-                                            [(<switch-designator>) $1]
-                                            [(OPEN <designational-expression> CLOSE) $2])
-         (<designational-expression> [(<simple-designational-expression>) $1]
-                                     [(IF <Boolean-expression> 
-                                          THEN <simple-designational-expression> 
-                                          ELSE <designational-expression>)
-				      (make-a60:if $2 $4 $6)])
-         ;; -------------------- Variables --------------------
-         (<subscript-list> [(<arithmetic-expression>) (list $1)]
-                           [(<subscript-list> COMMA <arithmetic-expression>) (append $1 (list $3))])
-         (<subscripted-variable> [(<identifier> OPENSQ <subscript-list> CLOSESQ) (make-a60:variable $1 $3)])
-         (<variable> [(<identifier>) (make-a60:variable $1 null)]
-                     [(<subscripted-variable>) $1])
-         ;; -------------------- Function calls --------------------
-         (<function-designator> [(<identifier> <actual-parameter-part>) (make-a60:app $1 $2)])
-         ;; ==================== Statements ====================
-         ;;  - - - - - - - - - - non-empty - - - - - - - - - - 
-         (<unlabelled-basic-nonempty-statement> [(<assignment-statement>) $1]
-                                                [(<go-to-statement>) $1]
-                                                [(<procedure-statement>) $1])
-         (<basic-nonempty-statement> [(<unlabelled-basic-nonempty-statement>) $1]
-                                     [(<label> COLON <basic-statement>) (make-a60:label $1 $3)])
-         (<unconditional-nonempty-statement> [(<basic-nonempty-statement>) $1]
-                                             [(<compound-statement>) $1]
-                                             [(<block>) $1])
-         (<nonempty-statement> [(<unconditional-nonempty-statement>) $1]
-                               [(<conditional-statement>) $1]
-                               [(<for-statement>) $1])
-         ;;  - - - - - - - - - - possibly empty - - - - - - - - - -          
-         (<unlabelled-basic-statement> [(<unlabelled-basic-nonempty-statement>) $1]
-                                       [(<dummy-statement>) $1])
-         (<basic-statement> [(<unlabelled-basic-statement>) $1]
-                            [(<label> COLON <basic-statement>) (make-a60:label $1 $3)])
-         (<unconditional-statement> [(<basic-statement>) $1]
-                                    [(<unconditional-nonempty-statement>) $1])
-         (<statement> [(<unconditional-statement>) $1]
-                      [(<nonempty-statement>) $1])
-         ;; -------------------- block and compound --------------------
-         (<compound-tail> [(<statement> END) (list $1)]
-                          [(<statement> SEMICOLON <compound-tail>) (cons $1 $3)])
-         (<block-head> [(BEGIN <declaration>) (list $2)]
-                       [(<block-head> SEMICOLON <declaration>) (append $1 (list $3))])
-         (<unlabelled-block> [(<block-head> SEMICOLON <compound-tail>) (make-a60:block $1 $3)])
-         (<unlabelled-compound> [(BEGIN <compound-tail>) (make-a60:compound $2)])
-         
-         (<compound-statement> [(<unlabelled-compound>) $1]
-                               [(<label> COLON <compound-statement>) (make-a60:label $1 $3)])
-         (<block> [(<unlabelled-block>) $1]
-                  [(<label> COLON <block>) (make-a60:label $1 $3)])
-         ;; -------------------- assignment --------------------
-         (<left-part> [(<variable> ASSIGN) $1])
-         (<left-part-list> [(<left-part>) (list $1)]
-                           [(<left-part-list> <left-part>) (append $1 (list $2))])
-         (<assignment-statement> [(<left-part-list> <arithmetic-expression>) (make-a60:assign $1 $2)]
-                                 [(<left-part-list> <Boolean-expression>) (make-a60:assign $1 $2)])
-         ;; -------------------- goto --------------------
-         (<go-to-statement> [(GOTO <designational-expression>) (make-a60:goto $2)])
-         ;; -------------------- dummy --------------------
-         (<dummy-statement> [() (make-a60:compound null)])
-         ;; -------------------- conditional --------------------
-         (<conditional-statement> [(IF <Boolean-expression> THEN <unconditional-statement>)
-                                   (make-a60:branch $2 $4 (make-a60:compound null))]
-                                  [(IF <Boolean-expression> THEN <unconditional-statement> ELSE <statement>)
-                                   (make-a60:branch $2 $4 $6)]
-                                  [(IF <Boolean-expression> THEN <for-statement>)
-                                   (make-a60:branch $2 $4 (make-a60:compound null))]
-                                  [(<label> COLON <conditional-statement>) (make-a60:label $1 $3)])
-         ;; -------------------- for --------------------
-         (<for-list-element> [(<arithmetic-expression>) (make-a60:for-number $1)]
-                             [(<arithmetic-expression> STEP <arithmetic-expression> UNTIL <arithmetic-expression>)
-                              (make-a60:for-step $1 $3 $5)]
-                             [(<arithmetic-expression> WHILE <Boolean-expression>) (make-a60:for-while $1 $3)])
-         (<for-list> [(<for-list-element>) (list $1)]
-                     [(<for-list> COMMA <for-list-element>) (append $1 (list $3))])
-         (<for-statement> [(FOR <variable> ASSIGN <for-list> DO <statement>)
-                           (make-a60:for $2 $4 $6)]
-                          [(<label> COLON <for-statement>) (make-a60:label $1 $3)])
-         ;; -------------------- procedure statement --------------------
-         (<actual-parameter> [(<string>) $1]
-                             [(<expression>) $1]
-                             ; [(<identifier>) $1] ; switch, array, or procedure
-                             )
-         (<parameter-delimiter> [(COMMA) (void)]
-                                [(CLOSE <identifier> COLON OPEN) (void)]) ;; <identifier> was <letter-string>!
-         (<actual-parameter-list> [(<actual-parameter>) (list $1)]
-                                  [(<actual-parameter-list> <parameter-delimiter> <actual-parameter>)
-                                   (append $1 (list $3))])
-         (<actual-parameter-part> [() null]
-                                  [(OPEN <actual-parameter-list> CLOSE) $2])
-         (<procedure-statement> [(<identifier> <actual-parameter-part>) (make-a60:call $1 $2)])
-         ;; ==================== Declarations ====================
-         (<declaration> [(<type-declaration>) $1]
-                        [(<array-declaration>) $1]
-                        [(<switch-declaration>) $1]
-                        [(<procedure-declaration>) $1])
-         ;; -------------------- Simple --------------------
-         (<type-list> [(<identifier>) (list $1)]
-                      [(<identifier> COMMA <type-list>) (cons $1 $3)])
-         (<local-or-own-type> [(<type>) $1]
-                              [(OWN <type>) (box $2)]) ; box => own
-         (<type-declaration> [(<local-or-own-type> <type-list>) (make-a60:type-decl $1 $2)])
-         ;; -------------------- Arrays --------------------
-         (<bound-pair> [(<arithmetic-expression> COLON <arithmetic-expression>) (cons $1 $3)])
-         (<bound-pair-list> [(<bound-pair>) (list $1)]
-                            [(<bound-pair-list> COMMA <bound-pair>) (append $1 (list $3))])
-         (<array-segment> [(<identifier> OPENSQ <bound-pair-list> CLOSESQ) (list (cons $1 $3))]
-                          [(<identifier> COMMA <array-segment>) (cons (cons $1 (cdar $3)) $3)])
-         (<array-list> [(<array-segment>) $1]
-                       [(<array-list> COMMA <array-segment>) (append $1 $3)])
-         (<array-declaration> [(ARRAY <array-list>) (make-a60:array-decl #'unknown $2)]
-                              [(<local-or-own-type> ARRAY <array-list>) (make-a60:array-decl $1 $3)])
-         ;; -------------------- Switches --------------------
-         (<switch-list> [(<designational-expression>) (list $1)]
-                        [(<switch-list> COMMA <designational-expression>) (append $1 (list $3))])
-         (<switch-declaration> [(SWITCH <switch-identifier> ASSIGN <switch-list>) (make-a60:switch-decl $2 $4)])
-         ;; -------------------- Procedures --------------------
-         (<formal-parameter> [(<identifier>) $1])
-         (<formal-parameter-list> [(<formal-parameter>) (list $1)]
-                                  [(<formal-parameter-list> <parameter-delimiter> <formal-parameter>) 
-                                   (append $1 (list $3))])
-         (<formal-parameter-part> [() null]
-                                  [(OPEN <formal-parameter-list> CLOSE) $2])
-         (<identifier-list> [(<identifier>) (list $1)]
-                            [(<identifier-list> COMMA <identifier>) (append $1 (list $3))])
-         (<value-part> [(VALUE <identifier-list> SEMICOLON) $2]
-                       [() null])
-         (<specifier> [(STRING) 'string]
-                      [(<type>) $1]
-                      [(ARRAY) '(array #'unknown)]
-                      [(<type> ARRAY) `(array ,$1)]
-                      [(LABEL) 'label]
-                      [(SWITCH) 'switch]
-                      [(PROCEDURE) '(procedure #'unknown)]
-                      [(<type> PROCEDURE) `(procedure ,$1)])
-         (<nonempty-specification-part> [(<specifier> <identifier-list> SEMICOLON) (list (cons $1 $2))]
-                                        [(<nonempty-specification-part> <specifier> <identifier-list> SEMICOLON)
-                                         (append $1 (list (cons $2 $3)))])
-         (<specification-part> [() null]
-                               [(<nonempty-specification-part>) $1])
-         (<procedure-heading> [(<identifier> <formal-parameter-part> SEMICOLON <value-part> <specification-part>)
-                               (list $1 $2 $4 $5)])
-         (<procedure-body> [(<nonempty-statement>) $1])
-         (<procedure-declaration> [(PROCEDURE <procedure-heading> <procedure-body>)
-                                   (make-a60:proc-decl #'unknown (car $2) (cadr $2) (caddr $2) (cadddr $2) $3)]
-                                  [(<type> PROCEDURE <procedure-heading> <procedure-body>)
-                                   (make-a60:proc-decl $1 (car $3) (cadr $3) (caddr $3) (cadddr $3) $4)])
-         ;; ==================== Program ====================
-         (<program> [(<block>) $1]
-                    [(<compound-statement>) $1]))))
-     
-     (define-syntax (define-a60-structs stx)
-       (syntax-case stx ()
-         [(_ (struct-name (field ...)) ...)
-          (with-syntax ([(a60:struct ...) (map (lambda (id)
-						 (datum->syntax-object
-						  id
-						  (string->symbol
-						   (format "a60:~a" (syntax-e id)))))
-                                               (syntax->list (syntax (struct-name ...))))])
-            (syntax (begin (define-struct a60:struct (field ...)) ...
-                           (provide (struct a60:struct (field ...)) ...))))]))
-     
-     (define-a60-structs
-      ;; Expressions
-      (if (test then else))
-      (unary (type argtype op arg))
-      (binary (type argtype op arg1 arg2))
-      (subscript (array index))
-      (variable (name indices))
-      (app (func args))
-      ;; plus numbers, strings, and booleans
+(provide parse-a60-file parse-a60-port)
 
-      ;; Statements
-      (block (decls statements))
-      (compound (statements))
-      (assign (variables rhs))
-      (goto (target))
-      (branch (test then else))
-      (call (proc args))
-      (for (variable values body))
-      (dummy ())
-      (label (name statement))
-      
-      ;; for values
-      (for-number (value))
-      (for-step (start step end))
-      (for-while (value test))
+(define-lex-abbrevs [lex:letter (:or (:/ #\a #\z) (:/ #\A #\Z))]
+  [lex:digit (:/ #\0 #\9)]
+  [lex:whitespace (:or #\newline #\return #\tab #\space #\vtab)]
+  [lex:comment (:: (:* lex:whitespace) "comment" (:* (:~ #\;)) #\;)])
 
-      ;; declarations
-      (type-decl (type vars))
-      (array-decl (type vars))
-      (switch-decl (var cases))
-      (proc-decl (result-type var arg-vars by-value-vars arg-specs body)))
-     
-     (define (parse-a60-port port file)
-       (let ([lexer (lex file)])
-	 (port-count-lines! port)
-         (parse
-          (lambda () 
-            (let loop ()
-              (let ([v (lexer port)])
-                (if (void? v)
-                    (loop)
-                    v)))))))
-     
-     (define (parse-a60-file file)
-       (with-input-from-file file
-         (lambda ()
-           (parse-a60-port (current-input-port)
-                           (path->complete-path file)))))
+(define-tokens non-terminals (<logical-value> 
+                              <type> <identifier> 
+                              <unsigned-integer> <unsigned-float> <string>
+                              
+                              GOTO IF THEN ELSE FOR DO STEP UNTIL WHILE
+                              OWN ARRAY STRING PROCEDURE SWITCH LABEL VALUE
+                              BEGIN END
+                              POWER PLUS MINUS TIMES SLASH DIVIDE
+                              LESS LESS-OR-EQUAL EQUAL GREATER-OR-EQUAL GREATER NOT-EQUAL ASSIGN
+                              NEGATE AND OR IMPLIES EQUIV
+                              COMMA COLON SEMICOLON
+                              OPEN CLOSE OPENSQ CLOSESQ
+                              EOF
+                              UNPARSEABLE))
 
-      (provide parse-a60-file parse-a60-port))
+(define stx-for-original-property (read-syntax #f (open-input-string "original")))
+
+(define-syntax (token stx)
+  (syntax-case stx ()
+    [(_ name val)
+     (identifier? (syntax name))
+     (let ([name (syntax name)])
+       (with-syntax ([token-name (datum->syntax
+                                  name
+                                  (string->symbol
+                                   (format "token-~a" (syntax-e name))))]
+                     [source-name (datum->syntax name 'source-name)]
+                     [start-pos (datum->syntax name 'start-pos)]
+                     [end-pos (datum->syntax name 'end-pos)])
+         (syntax 
+          (token-name 
+           (datum->syntax #f val
+                                 (list
+                                  source-name
+                                  (position-line start-pos)
+                                  (position-col start-pos)
+                                  (position-offset start-pos)
+                                  (- (position-offset end-pos)
+                                     (position-offset start-pos)))
+                                 stx-for-original-property)))))]))
+(define-syntax (ttoken stx)
+  (syntax-case stx ()
+    [(_ name)
+     (identifier? (syntax name))
+     (syntax (token name 'name))]))
+
+(define (lex source-name)
+  (lexer
+   [(:+ lex:whitespace) (void)]
+   ["true" (token <logical-value> #t)]
+   ["false" (token <logical-value> #f)]
+   ["real" (token <type> 'real)]
+   ["integer" (token <type> 'integer)]
+   ["Boolean" (token <type> 'boolean)]
+   ["goto" (ttoken GOTO)]
+   ["if" (ttoken IF)]
+   ["then" (ttoken THEN)]
+   ["else" (ttoken ELSE)]
+   ["for" (ttoken FOR)]
+   ["do" (ttoken DO)]
+   ["step" (ttoken STEP)]
+   ["until" (ttoken UNTIL)]
+   ["while" (ttoken WHILE)]
+   ["own" (ttoken OWN)]
+   ["array" (ttoken ARRAY)]
+   ["string" (ttoken STRING)]
+   ["procedure" (ttoken PROCEDURE)]
+   ["switch" (ttoken SWITCH)]
+   ["label" (ttoken LABEL)]
+   ["value" (ttoken VALUE)]
+   [(:: "begin" lex:comment) (ttoken BEGIN)]
+   ["begin" (ttoken BEGIN)]
+   [(:: "end" lex:comment) (ttoken BEGIN)]
+   ["end" (ttoken END)]
+   ["^" (token POWER 'expt)]
+   ["+" (token PLUS '+)]
+   ["-" (token MINUS '-)]
+   ["*" (token TIMES '*)]
+   ["/" (token SLASH '/)]
+   ["div" (token DIVIDE 'quotient)]
+   ["<" (token LESS '<)]
+   ["<=" (token LESS-OR-EQUAL '<=)]
+   ["=" (token EQUAL '=)]
+   [">" (token GREATER '>)]
+   [">=" (token GREATER-OR-EQUAL '>=)]
+   ["!=" (token NOT-EQUAL '!=)]
+   ["!" (token NEGATE '!)]
+   ["&" (token AND '&)]
+   ["|" (token OR '\|)]
+   ["=>" (token IMPLIES '==>)]
+   ["==" (token EQUIV '==)]
+   [":=" (ttoken ASSIGN)]
+   ["," (ttoken COMMA)]
+   [":" (ttoken COLON)]
+   [(:: ";" lex:comment) (ttoken SEMICOLON)]
+   [";" (ttoken SEMICOLON)]
+   ["(" (ttoken OPEN)]
+   [")" (ttoken CLOSE)]
+   ["[" (ttoken OPENSQ)]
+   ["]" (ttoken CLOSESQ)]
+   [(:: lex:letter (:* (:or lex:letter lex:digit))) (token <identifier> (string->symbol lexeme))]
+   [(:+ lex:digit) (token <unsigned-integer> (string->number lexeme))]
+   [(:or (:: (:+ lex:digit) #\. (:* lex:digit))
+         (:: (:* lex:digit) #\. (:+ lex:digit))) (token <unsigned-float> (string->number lexeme))]
+   [(:: #\` (:* (:~ #\' #\`)) #\') (let ([s lexeme])
+                                     (token <string> (substring s 1 (sub1 (string-length s)))))]
+   [(eof) (ttoken EOF)]
+   [any-char (token UNPARSEABLE (string->symbol lexeme))]))
+
+(define parse
+  (cfg-parser
+   (tokens non-terminals)
+   (start <program>)
+   (end EOF)
+   (error (lambda (_ name stx start end) 
+            (raise-read-error (format "parse error near ~a" name)
+                              (syntax-source stx)
+                              (syntax-line stx)
+                              (syntax-column stx)
+                              (syntax-position stx)
+                              (syntax-span stx))))
+   (suppress)
+   (grammar 
+    ;; ==================== Expressions ====================
+    (<expression> [(<arithmetic-expression>) $1]
+                  [(<Boolean-expression>) $1]
+                  [(<designational-expression>) $1])
+    ;; -------------------- Numbers --------------------
+    (<arithmetic-expression> [(<simple-arithmetic-expression>) $1]
+                             [(IF <Boolean-expression> 
+                                  THEN <simple-arithmetic-expression> 
+                                  ELSE <arithmetic-expression>)
+                              (make-a60:if $2 $4 $6)])
+    (<simple-arithmetic-expression> [(<term>) $1]
+                                    [(<adding-operator> <term>) (make-a60:unary 'num 'num $1 $2)]
+                                    [(<simple-arithmetic-expression> <adding-operator> <term>) 
+                                     (make-a60:binary 'num 'num $2 $1 $3)])
+    (<term> [(<factor>) $1]
+            [(<term> <multiplying-operator> <factor>) (make-a60:binary 'num 'num $2 $1 $3)])
+    (<factor> [(<primary>) $1]
+              [(<factor> POWER <primary>) (make-a60:binary 'num 'num $2 $1 $3)])
+    (<adding-operator> [(PLUS) $1]
+                       [(MINUS) $1])
+    (<multiplying-operator> [(TIMES) $1]
+                            [(SLASH) $1]
+                            [(DIVIDE) $1])
+    (<primary> [(<unsigned-integer>) $1]
+               [(<unsigned-float>) $1]
+               [(<variable>) $1]
+               [(<function-designator>) $1]
+               [(OPEN <arithmetic-expression> CLOSE) $2])
+    ;; -------------------- Booleans --------------------
+    (<relational-operator> [(LESS) $1]
+                           [(LESS-OR-EQUAL) $1]
+                           [(EQUAL) $1]
+                           [(GREATER-OR-EQUAL) $1]
+                           [(GREATER) $1]
+                           [(NOT-EQUAL) $1])
+    (<relation> [(<simple-arithmetic-expression> <relational-operator> <simple-arithmetic-expression>)
+                 (make-a60:binary 'bool 'num $2 $1 $3)])
+    (<Boolean-primary> [(<logical-value>) $1]
+                       [(<variable>) $1]
+                       [(<function-designator>) $1]
+                       [(<relation>) $1]
+                       [(OPEN <Boolean-expression> CLOSE) $2])
+    (<Boolean-secondary> [(<Boolean-primary>) $1]
+                         [(NEGATE <Boolean-primary>) (make-a60:unary 'bool 'bool $1 $2)])
+    (<Boolean-factor> [(<Boolean-secondary>) $1]
+                      [(<Boolean-factor> AND <Boolean-secondary>) (make-a60:binary 'bool 'bool $2 $1 $3)])
+    (<Boolean-term> [(<Boolean-factor>) $1]
+                    [(<Boolean-term> OR <Boolean-factor>)  (make-a60:binary 'bool 'bool $2 $1 $3)])
+    
+    (<implication> [(<Boolean-term>) $1]
+                   [(<implication> IMPLIES <Boolean-term>) (make-a60:binary 'bool 'bool $2 $1 $3)])
+    (<simple-Boolean> [(<implication>) $1]
+                      [(<simple-Boolean> EQUIV <implication>) (make-a60:binary 'bool 'bool $2 $1 $3)])
+    (<Boolean-expression> [(<simple-Boolean>) $1]
+                          [(IF <Boolean-expression> 
+                               THEN <simple-Boolean> 
+                               ELSE <Boolean-expression>)
+                           (make-a60:if $2 $4 $6)])
+    ;; -------------------- Designationals --------------------
+    (<label> [(<identifier>) $1]
+             [(<unsigned-integer>) $1])
+    (<switch-identifier> [(<identifier>) $1])
+    (<switch-designator> [(<switch-identifier> OPENSQ <arithmetic-expression> CLOSESQ)
+                          (make-a60:subscript $1 $3)])
+    (<simple-designational-expression> [(<label>) $1]
+                                       [(<switch-designator>) $1]
+                                       [(OPEN <designational-expression> CLOSE) $2])
+    (<designational-expression> [(<simple-designational-expression>) $1]
+                                [(IF <Boolean-expression> 
+                                     THEN <simple-designational-expression> 
+                                     ELSE <designational-expression>)
+                                 (make-a60:if $2 $4 $6)])
+    ;; -------------------- Variables --------------------
+    (<subscript-list> [(<arithmetic-expression>) (list $1)]
+                      [(<subscript-list> COMMA <arithmetic-expression>) (append $1 (list $3))])
+    (<subscripted-variable> [(<identifier> OPENSQ <subscript-list> CLOSESQ) (make-a60:variable $1 $3)])
+    (<variable> [(<identifier>) (make-a60:variable $1 null)]
+                [(<subscripted-variable>) $1])
+    ;; -------------------- Function calls --------------------
+    (<function-designator> [(<identifier> <actual-parameter-part>) (make-a60:app $1 $2)])
+    ;; ==================== Statements ====================
+    ;;  - - - - - - - - - - non-empty - - - - - - - - - - 
+    (<unlabelled-basic-nonempty-statement> [(<assignment-statement>) $1]
+                                           [(<go-to-statement>) $1]
+                                           [(<procedure-statement>) $1])
+    (<basic-nonempty-statement> [(<unlabelled-basic-nonempty-statement>) $1]
+                                [(<label> COLON <basic-statement>) (make-a60:label $1 $3)])
+    (<unconditional-nonempty-statement> [(<basic-nonempty-statement>) $1]
+                                        [(<compound-statement>) $1]
+                                        [(<block>) $1])
+    (<nonempty-statement> [(<unconditional-nonempty-statement>) $1]
+                          [(<conditional-statement>) $1]
+                          [(<for-statement>) $1])
+    ;;  - - - - - - - - - - possibly empty - - - - - - - - - -          
+    (<unlabelled-basic-statement> [(<unlabelled-basic-nonempty-statement>) $1]
+                                  [(<dummy-statement>) $1])
+    (<basic-statement> [(<unlabelled-basic-statement>) $1]
+                       [(<label> COLON <basic-statement>) (make-a60:label $1 $3)])
+    (<unconditional-statement> [(<basic-statement>) $1]
+                               [(<unconditional-nonempty-statement>) $1])
+    (<statement> [(<unconditional-statement>) $1]
+                 [(<nonempty-statement>) $1])
+    ;; -------------------- block and compound --------------------
+    (<compound-tail> [(<statement> END) (list $1)]
+                     [(<statement> SEMICOLON <compound-tail>) (cons $1 $3)])
+    (<block-head> [(BEGIN <declaration>) (list $2)]
+                  [(<block-head> SEMICOLON <declaration>) (append $1 (list $3))])
+    (<unlabelled-block> [(<block-head> SEMICOLON <compound-tail>) (make-a60:block $1 $3)])
+    (<unlabelled-compound> [(BEGIN <compound-tail>) (make-a60:compound $2)])
+    
+    (<compound-statement> [(<unlabelled-compound>) $1]
+                          [(<label> COLON <compound-statement>) (make-a60:label $1 $3)])
+    (<block> [(<unlabelled-block>) $1]
+             [(<label> COLON <block>) (make-a60:label $1 $3)])
+    ;; -------------------- assignment --------------------
+    (<left-part> [(<variable> ASSIGN) $1])
+    (<left-part-list> [(<left-part>) (list $1)]
+                      [(<left-part-list> <left-part>) (append $1 (list $2))])
+    (<assignment-statement> [(<left-part-list> <arithmetic-expression>) (make-a60:assign $1 $2)]
+                            [(<left-part-list> <Boolean-expression>) (make-a60:assign $1 $2)])
+    ;; -------------------- goto --------------------
+    (<go-to-statement> [(GOTO <designational-expression>) (make-a60:goto $2)])
+    ;; -------------------- dummy --------------------
+    (<dummy-statement> [() (make-a60:compound null)])
+    ;; -------------------- conditional --------------------
+    (<conditional-statement> [(IF <Boolean-expression> THEN <unconditional-statement>)
+                              (make-a60:branch $2 $4 (make-a60:compound null))]
+                             [(IF <Boolean-expression> THEN <unconditional-statement> ELSE <statement>)
+                              (make-a60:branch $2 $4 $6)]
+                             [(IF <Boolean-expression> THEN <for-statement>)
+                              (make-a60:branch $2 $4 (make-a60:compound null))]
+                             [(<label> COLON <conditional-statement>) (make-a60:label $1 $3)])
+    ;; -------------------- for --------------------
+    (<for-list-element> [(<arithmetic-expression>) (make-a60:for-number $1)]
+                        [(<arithmetic-expression> STEP <arithmetic-expression> UNTIL <arithmetic-expression>)
+                         (make-a60:for-step $1 $3 $5)]
+                        [(<arithmetic-expression> WHILE <Boolean-expression>) (make-a60:for-while $1 $3)])
+    (<for-list> [(<for-list-element>) (list $1)]
+                [(<for-list> COMMA <for-list-element>) (append $1 (list $3))])
+    (<for-statement> [(FOR <variable> ASSIGN <for-list> DO <statement>)
+                      (make-a60:for $2 $4 $6)]
+                     [(<label> COLON <for-statement>) (make-a60:label $1 $3)])
+    ;; -------------------- procedure statement --------------------
+    (<actual-parameter> [(<string>) $1]
+                        [(<expression>) $1]
+                        ; [(<identifier>) $1] ; switch, array, or procedure
+                        )
+    (<parameter-delimiter> [(COMMA) (void)]
+                           [(CLOSE <identifier> COLON OPEN) (void)]) ;; <identifier> was <letter-string>!
+    (<actual-parameter-list> [(<actual-parameter>) (list $1)]
+                             [(<actual-parameter-list> <parameter-delimiter> <actual-parameter>)
+                              (append $1 (list $3))])
+    (<actual-parameter-part> [() null]
+                             [(OPEN <actual-parameter-list> CLOSE) $2])
+    (<procedure-statement> [(<identifier> <actual-parameter-part>) (make-a60:call $1 $2)])
+    ;; ==================== Declarations ====================
+    (<declaration> [(<type-declaration>) $1]
+                   [(<array-declaration>) $1]
+                   [(<switch-declaration>) $1]
+                   [(<procedure-declaration>) $1])
+    ;; -------------------- Simple --------------------
+    (<type-list> [(<identifier>) (list $1)]
+                 [(<identifier> COMMA <type-list>) (cons $1 $3)])
+    (<local-or-own-type> [(<type>) $1]
+                         [(OWN <type>) (box $2)]) ; box => own
+    (<type-declaration> [(<local-or-own-type> <type-list>) (make-a60:type-decl $1 $2)])
+    ;; -------------------- Arrays --------------------
+    (<bound-pair> [(<arithmetic-expression> COLON <arithmetic-expression>) (cons $1 $3)])
+    (<bound-pair-list> [(<bound-pair>) (list $1)]
+                       [(<bound-pair-list> COMMA <bound-pair>) (append $1 (list $3))])
+    (<array-segment> [(<identifier> OPENSQ <bound-pair-list> CLOSESQ) (list (cons $1 $3))]
+                     [(<identifier> COMMA <array-segment>) (cons (cons $1 (cdar $3)) $3)])
+    (<array-list> [(<array-segment>) $1]
+                  [(<array-list> COMMA <array-segment>) (append $1 $3)])
+    (<array-declaration> [(ARRAY <array-list>) (make-a60:array-decl #'unknown $2)]
+                         [(<local-or-own-type> ARRAY <array-list>) (make-a60:array-decl $1 $3)])
+    ;; -------------------- Switches --------------------
+    (<switch-list> [(<designational-expression>) (list $1)]
+                   [(<switch-list> COMMA <designational-expression>) (append $1 (list $3))])
+    (<switch-declaration> [(SWITCH <switch-identifier> ASSIGN <switch-list>) (make-a60:switch-decl $2 $4)])
+    ;; -------------------- Procedures --------------------
+    (<formal-parameter> [(<identifier>) $1])
+    (<formal-parameter-list> [(<formal-parameter>) (list $1)]
+                             [(<formal-parameter-list> <parameter-delimiter> <formal-parameter>) 
+                              (append $1 (list $3))])
+    (<formal-parameter-part> [() null]
+                             [(OPEN <formal-parameter-list> CLOSE) $2])
+    (<identifier-list> [(<identifier>) (list $1)]
+                       [(<identifier-list> COMMA <identifier>) (append $1 (list $3))])
+    (<value-part> [(VALUE <identifier-list> SEMICOLON) $2]
+                  [() null])
+    (<specifier> [(STRING) 'string]
+                 [(<type>) $1]
+                 [(ARRAY) '(array #'unknown)]
+                 [(<type> ARRAY) `(array ,$1)]
+                 [(LABEL) 'label]
+                 [(SWITCH) 'switch]
+                 [(PROCEDURE) '(procedure #'unknown)]
+                 [(<type> PROCEDURE) `(procedure ,$1)])
+    (<nonempty-specification-part> [(<specifier> <identifier-list> SEMICOLON) (list (cons $1 $2))]
+                                   [(<nonempty-specification-part> <specifier> <identifier-list> SEMICOLON)
+                                    (append $1 (list (cons $2 $3)))])
+    (<specification-part> [() null]
+                          [(<nonempty-specification-part>) $1])
+    (<procedure-heading> [(<identifier> <formal-parameter-part> SEMICOLON <value-part> <specification-part>)
+                          (list $1 $2 $4 $5)])
+    (<procedure-body> [(<nonempty-statement>) $1])
+    (<procedure-declaration> [(PROCEDURE <procedure-heading> <procedure-body>)
+                              (make-a60:proc-decl #'unknown (car $2) (cadr $2) (caddr $2) (cadddr $2) $3)]
+                             [(<type> PROCEDURE <procedure-heading> <procedure-body>)
+                              (make-a60:proc-decl $1 (car $3) (cadr $3) (caddr $3) (cadddr $3) $4)])
+    ;; ==================== Program ====================
+    (<program> [(<block>) $1]
+               [(<compound-statement>) $1]))))
+
+(define-syntax (define-a60-structs stx)
+  (syntax-case stx ()
+    [(_ (struct-name (field ...)) ...)
+     (with-syntax ([(a60:struct ...) (map (lambda (id)
+                                            (datum->syntax
+                                             id
+                                             (string->symbol
+                                              (format "a60:~a" (syntax-e id)))))
+                                          (syntax->list (syntax (struct-name ...))))])
+       (syntax (begin (define-struct a60:struct (field ...)) ...
+                      (provide (struct-out a60:struct) ...))))]))
+
+(define-a60-structs
+  ;; Expressions
+  (if (test then else))
+  (unary (type argtype op arg))
+  (binary (type argtype op arg1 arg2))
+  (subscript (array index))
+  (variable (name indices))
+  (app (func args))
+  ;; plus numbers, strings, and booleans
+  
+  ;; Statements
+  (block (decls statements))
+  (compound (statements))
+  (assign (variables rhs))
+  (goto (target))
+  (branch (test then else))
+  (call (proc args))
+  (for (variable values body))
+  (dummy ())
+  (label (name statement))
+  
+  ;; for values
+  (for-number (value))
+  (for-step (start step end))
+  (for-while (value test))
+  
+  ;; declarations
+  (type-decl (type vars))
+  (array-decl (type vars))
+  (switch-decl (var cases))
+  (proc-decl (result-type var arg-vars by-value-vars arg-specs body)))
+
+(define (parse-a60-port port file)
+  (let ([lexer (lex file)])
+    (port-count-lines! port)
+    (parse
+     (lambda () 
+       (let loop ()
+         (let ([v (lexer port)])
+           (if (void? v)
+               (loop)
+               v)))))))
+
+(define (parse-a60-file file)
+  (with-input-from-file file
+    (lambda ()
+      (parse-a60-port (current-input-port)
+                      (path->complete-path file)))))

--- a/collects/algol60/prims.rkt
+++ b/collects/algol60/prims.rkt
@@ -1,106 +1,106 @@
-(module prims mzscheme
-  (provide != ! & \|
-           ==> ==
-           sign entier
+#lang racket
+(provide != ! & \|
+         ==> ==
+         sign entier
+         
+         a60:sin
+         a60:cos
+         a60:arctan
+         a60:sqrt
+         a60:abs
+         a60:ln
+         a60:exp
+         
+         prints printn
+         printsln printnln)
 
-	   a60:sin
-           a60:cos
-           a60:arctan
-           a60:sqrt
-           a60:abs
-           a60:ln
-           a60:exp
+(define (!= a b)
+  (not (= a b)))
 
-           prints printn
-           printsln printnln)
-  
-  (define (!= a b)
-    (not (= a b)))
-  
-  (define (! a)
-    (unless (boolean? a)
-      (raise-type-error '! "boolean" a))
-    (not a))
-  
-  (define (& a b)
-    (unless (boolean? a)
-      (raise-type-error '& "boolean" 0 a b))
-    (unless (boolean? b)
-      (raise-type-error '& "boolean" 1 a b))
-    (and a b))
-  
-  (define (\| a b)
-    (unless (boolean? a)
-      (raise-type-error '\| "boolean" 0 a b))
-    (unless (boolean? b)
-      (raise-type-error '\| "boolean" 1 a b))
-    (or a b))
-  
-  (define (==> a b)
-    (unless (boolean? a)
-      (raise-type-error '=> "boolean" 0 a b))
-    (unless (boolean? b)
-      (raise-type-error '=> "boolean" 1 a b))
-    (or (not a) b))
-  
-  (define (== a b)
-    (unless (boolean? a)
-      (raise-type-error '== "boolean" 0 a b))
-    (unless (boolean? b)
-      (raise-type-error '== "boolean" 1 a b))
-    (eq? a b))
-  
-  (define (get-number who v)
-    (let ([v (v)])
-      (unless (number? v)
-	(raise-type-error who "number" v))
-      v))
+(define (! a)
+  (unless (boolean? a)
+    (raise-type-error '! "boolean" a))
+  (not a))
 
-  (define (get-string who v)
-    (let ([v (v)])
-      (unless (string? v)
-	(raise-type-error who "string" v))
-      v))
+(define (& a b)
+  (unless (boolean? a)
+    (raise-type-error '& "boolean" 0 a b))
+  (unless (boolean? b)
+    (raise-type-error '& "boolean" 1 a b))
+  (and a b))
 
-  (define (sign k v)
-    (k (let ([v (get-number 'sign v)])
-         (cond
-           [(< v 0) -1]
-           [(> v 0) 1]
-           [else 0]))))
-  
-  (define (entier k v)
-    (k (inexact->exact (floor (get-number 'entier v)))))
+(define (\| a b)
+  (unless (boolean? a)
+    (raise-type-error '\| "boolean" 0 a b))
+  (unless (boolean? b)
+    (raise-type-error '\| "boolean" 1 a b))
+  (or a b))
 
-  (define (a60:abs k v)
-    (k (abs (get-number 'abs v))))
-  
-  (define (a60:sqrt k v)
-    (k (sqrt (get-number 'sqrt v))))
-  
-  (define (a60:sin k v)
-    (k (sin (get-number 'sin v))))
-  
-  (define (a60:cos k v)
-    (k (cos (get-number 'cos v))))
-  
-  (define (a60:exp k v)
-    (k (exp (get-number 'exp v))))
-  
-  (define (a60:arctan k v)
-    (k (atan (get-number 'arctan v))))
-  
-  (define (a60:ln k v)
-    (k (log (get-number 'ln v))))
-  
-  (define (printsln k v)
-    (k (printf "~a\n" (get-string 'printsln v))))
-  
-  (define (printnln k v)
-    (k (printf "~a\n" (get-number 'printnln v))))
-  
-  (define (prints k v)
-    (k (printf "~a" (get-string 'prints v))))
-  
-  (define (printn k v)
-    (k (printf "~a" (get-number 'printn v)))))
+(define (==> a b)
+  (unless (boolean? a)
+    (raise-type-error '=> "boolean" 0 a b))
+  (unless (boolean? b)
+    (raise-type-error '=> "boolean" 1 a b))
+  (or (not a) b))
+
+(define (== a b)
+  (unless (boolean? a)
+    (raise-type-error '== "boolean" 0 a b))
+  (unless (boolean? b)
+    (raise-type-error '== "boolean" 1 a b))
+  (eq? a b))
+
+(define (get-number who v)
+  (let ([v (v)])
+    (unless (number? v)
+      (raise-type-error who "number" v))
+    v))
+
+(define (get-string who v)
+  (let ([v (v)])
+    (unless (string? v)
+      (raise-type-error who "string" v))
+    v))
+
+(define (sign k v)
+  (k (let ([v (get-number 'sign v)])
+       (cond
+         [(< v 0) -1]
+         [(> v 0) 1]
+         [else 0]))))
+
+(define (entier k v)
+  (k (inexact->exact (floor (get-number 'entier v)))))
+
+(define (a60:abs k v)
+  (k (abs (get-number 'abs v))))
+
+(define (a60:sqrt k v)
+  (k (sqrt (get-number 'sqrt v))))
+
+(define (a60:sin k v)
+  (k (sin (get-number 'sin v))))
+
+(define (a60:cos k v)
+  (k (cos (get-number 'cos v))))
+
+(define (a60:exp k v)
+  (k (exp (get-number 'exp v))))
+
+(define (a60:arctan k v)
+  (k (atan (get-number 'arctan v))))
+
+(define (a60:ln k v)
+  (k (log (get-number 'ln v))))
+
+(define (printsln k v)
+  (k (printf "~a\n" (get-string 'printsln v))))
+
+(define (printnln k v)
+  (k (printf "~a\n" (get-number 'printnln v))))
+
+(define (prints k v)
+  (k (printf "~a" (get-string 'prints v))))
+
+(define (printn k v)
+  (k (printf "~a" (get-number 'printn v))))

--- a/collects/algol60/runtime.rkt
+++ b/collects/algol60/runtime.rkt
@@ -1,108 +1,108 @@
-(module runtime mzscheme
-  
-  (provide (struct a60:array (vec dimens))
-           (struct a60:switch (choices))
-           undefined
-           check-boolean
-           goto
-           get-value
-           set-target!
-           make-array
-           array-ref
-           array-set!
-           make-switch
-           switch-ref
-           coerce)
-           
-  (define-struct a60:array (vec dimens))
-  (define-struct a60:switch (choices))
-  
-  (define undefined (letrec ([x x]) x))
-  (define (check-boolean b) b)
-  (define (goto f) (f))
-  (define (get-value v) (v))
-  (define (set-target! t name v)
-    (unless (procedure-arity-includes? t 1)
-      (error 'assignment "formal-argument variable ~a is assigned, but actual argument was not assignable"
-             name))
-    (t v))
-  
-  (define (bad what v)
-    (error '|bad value| "expected a ~a, got ~e" what v))
-  (define (coerce type v)
-    (cond
-      [(eq? type 'integer) 
-       (if (number? v)
-           (inexact->exact (floor v))
-           (bad 'number v))]
-      [(eq? type 'real) 
-       (if (number? v)
-           (exact->inexact v)
-           (bad 'number v))]
-      [(eq? type 'boolean) 
-       (if (boolean? v)
-           v
-           (bad 'boolean v))]
-      [else v]))
-  
-  (define (make-array . dimens)
-    (make-a60:array
-     ((let loop ([dimens dimens])
-        (if (null? dimens)
-            (lambda () undefined)
-            (let ([start (car dimens)]
-                  [end (cadr dimens)])
-              (let ([build (loop (cddr dimens))])
-                (lambda () 
-                  (let ([len (add1 (- end start))])
-                    (let ([v (make-vector len)])
-                      (let loop ([len len])
-                        (unless (zero? len)
-                          (vector-set! v (sub1 len) (build))
-                          (loop (sub1 len))))
-                      v))))))))
-     dimens))
+#lang racket
 
-  (define (check-array a is who)
-    (unless (a60:array? a)
-      (error who "not an array: ~e" a))
-    (unless (= (length is) (/ (length (a60:array-dimens a)) 2))
-      (error who "array dimension ~a doesn't match the number of provided indices ~a"
-             (length is) (/ (length (a60:array-dimens a)) 2))))
-  
-  (define (check-index who dimens indices)
-    (unless (and (number? (car indices))
-                 (exact? (car indices))
-                 (integer? (car indices)))
-      (error who "index is not an integer: ~e"
-             (car indices)))
-    (unless (<= (car dimens) (car indices) (cadr dimens))
-      (error who "index ~a out of range ~a:~a"
-             (car indices) (car dimens) (cadr dimens))))
-  
-  (define (array-ref a . indices)
-    (check-array a indices 'array-reference)
-    (let loop ([v (a60:array-vec a)][indices indices][dimens (a60:array-dimens a)])
-      (check-index 'array-reference dimens indices)
-      (let ([i (vector-ref v (- (car indices) (car dimens)))])
-        (if (null? (cdr indices))
-            i
-            (loop i (cdr indices) (cddr dimens))))))
-  
-  (define (array-set! a val . indices)
-    (check-array a indices 'array-assignment)
-    (let loop ([v (a60:array-vec a)][indices indices][dimens (a60:array-dimens a)])
-      (check-index 'array-assignment dimens indices)
+(provide (struct-out a60:array)
+         (struct-out a60:switch)
+         undefined
+         check-boolean
+         goto
+         get-value
+         set-target!
+         make-array
+         array-ref
+         array-set!
+         make-switch
+         switch-ref
+         coerce)
+
+(define-struct a60:array (vec dimens))
+(define-struct a60:switch (choices))
+
+(define undefined (letrec ([x x]) x))
+(define (check-boolean b) b)
+(define (goto f) (f))
+(define (get-value v) (v))
+(define (set-target! t name v)
+  (unless (procedure-arity-includes? t 1)
+    (error 'assignment "formal-argument variable ~a is assigned, but actual argument was not assignable"
+           name))
+  (t v))
+
+(define (bad what v)
+  (error '|bad value| "expected a ~a, got ~e" what v))
+(define (coerce type v)
+  (cond
+    [(eq? type 'integer) 
+     (if (number? v)
+         (inexact->exact (floor v))
+         (bad 'number v))]
+    [(eq? type 'real) 
+     (if (number? v)
+         (exact->inexact v)
+         (bad 'number v))]
+    [(eq? type 'boolean) 
+     (if (boolean? v)
+         v
+         (bad 'boolean v))]
+    [else v]))
+
+(define (make-array . dimens)
+  (make-a60:array
+   ((let loop ([dimens dimens])
+      (if (null? dimens)
+          (lambda () undefined)
+          (let ([start (car dimens)]
+                [end (cadr dimens)])
+            (let ([build (loop (cddr dimens))])
+              (lambda () 
+                (let ([len (add1 (- end start))])
+                  (let ([v (make-vector len)])
+                    (let loop ([len len])
+                      (unless (zero? len)
+                        (vector-set! v (sub1 len) (build))
+                        (loop (sub1 len))))
+                    v))))))))
+   dimens))
+
+(define (check-array a is who)
+  (unless (a60:array? a)
+    (error who "not an array: ~e" a))
+  (unless (= (length is) (/ (length (a60:array-dimens a)) 2))
+    (error who "array dimension ~a doesn't match the number of provided indices ~a"
+           (length is) (/ (length (a60:array-dimens a)) 2))))
+
+(define (check-index who dimens indices)
+  (unless (and (number? (car indices))
+               (exact? (car indices))
+               (integer? (car indices)))
+    (error who "index is not an integer: ~e"
+           (car indices)))
+  (unless (<= (car dimens) (car indices) (cadr dimens))
+    (error who "index ~a out of range ~a:~a"
+           (car indices) (car dimens) (cadr dimens))))
+
+(define (array-ref a . indices)
+  (check-array a indices 'array-reference)
+  (let loop ([v (a60:array-vec a)][indices indices][dimens (a60:array-dimens a)])
+    (check-index 'array-reference dimens indices)
+    (let ([i (vector-ref v (- (car indices) (car dimens)))])
       (if (null? (cdr indices))
-          (vector-set! v (- (car indices) (car dimens)) val)
-          (loop (vector-ref v (- (car indices) (car dimens))) (cdr indices) (cddr dimens)))))
-  
-  (define (make-switch . choices)
-    (make-a60:switch (list->vector choices)))
-  (define (switch-ref sw index)
-    (unless (and (number? index)
-                 (integer? index)
-                 (exact? index)
-                 (<= 1 index (vector-length (a60:switch-choices sw))))
-      (error "bad switch index: " index))
-    ((vector-ref (a60:switch-choices sw) (sub1 index)))))
+          i
+          (loop i (cdr indices) (cddr dimens))))))
+
+(define (array-set! a val . indices)
+  (check-array a indices 'array-assignment)
+  (let loop ([v (a60:array-vec a)][indices indices][dimens (a60:array-dimens a)])
+    (check-index 'array-assignment dimens indices)
+    (if (null? (cdr indices))
+        (vector-set! v (- (car indices) (car dimens)) val)
+        (loop (vector-ref v (- (car indices) (car dimens))) (cdr indices) (cddr dimens)))))
+
+(define (make-switch . choices)
+  (make-a60:switch (list->vector choices)))
+(define (switch-ref sw index)
+  (unless (and (number? index)
+               (integer? index)
+               (exact? index)
+               (<= 1 index (vector-length (a60:switch-choices sw))))
+    (error "bad switch index: " index))
+  ((vector-ref (a60:switch-choices sw) (sub1 index))))

--- a/collects/algol60/simplify.rkt
+++ b/collects/algol60/simplify.rkt
@@ -1,169 +1,168 @@
-#cs(module simplify mzscheme
-     (require "parse.rkt"
-              "prims.rkt"
-              mzlib/match)
+#lang racket
+(require "parse.rkt"
+         (except-in racket/match ==))
 
-     (provide simplify)
+(provide simplify)
 
-     ;; flatten/label-block : list-of-decl list-of-stmt -> block-stmt
-     ;; Desugars `for', converts `if' so that it's always of the form
-     ;; `if <test> then goto <label> else goto <label>', flattens
-     ;; compound statements into the enclosing block, and gives every
-     ;; statement exactly one label. The result usually has lots of
-     ;; "dummy" statements that could easily be eliminated by merging
-     ;; labels.
-     (define (flatten/label-block decls statements ->stx)
-       (define extra-decls null)
-       (define new-statements
-         (let loop ([l statements])
-           (if (null? l)
-               null
-               (match (car l)
-                 [($ a60:block decls statements)
-                  (cons (cons (gensym 'block) (flatten/label-block decls statements ->stx))
-                        (loop (cdr l)))]
-                 [($ a60:compound statements)
-                  (loop (append statements (cdr l)))]
-                 [($ a60:branch test then else)
-                  (if (and (a60:goto? then) (a60:goto? else))
-                      (cons (cons (gensym 'branch) (car l))
-                            (loop (cdr l)))
-                      (let ([then-label (gensym 'then)]
-                            [else-label (gensym 'else)]
-                            [cont-label (gensym 'if-cont)])
-                        (loop
-                         (list*
-                          (make-a60:branch test (make-a60:goto then-label) (make-a60:goto else-label))
-                          (make-a60:label then-label then)
+;; flatten/label-block : list-of-decl list-of-stmt -> block-stmt
+;; Desugars `for', converts `if' so that it's always of the form
+;; `if <test> then goto <label> else goto <label>', flattens
+;; compound statements into the enclosing block, and gives every
+;; statement exactly one label. The result usually has lots of
+;; "dummy" statements that could easily be eliminated by merging
+;; labels.
+(define (flatten/label-block decls statements ->stx)
+  (define extra-decls null)
+  (define new-statements
+    (let loop ([l statements])
+      (if (null? l)
+          null
+          (match (car l)
+            [(a60:block decls statements)
+             (cons (cons (gensym 'block) (flatten/label-block decls statements ->stx))
+                   (loop (cdr l)))]
+            [(a60:compound statements)
+             (loop (append statements (cdr l)))]
+            [(a60:branch test then else)
+             (if (and (a60:goto? then) (a60:goto? else))
+                 (cons (cons (gensym 'branch) (car l))
+                       (loop (cdr l)))
+                 (let ([then-label (gensym 'then)]
+                       [else-label (gensym 'else)]
+                       [cont-label (gensym 'if-cont)])
+                   (loop
+                    (list*
+                     (make-a60:branch test (make-a60:goto then-label) (make-a60:goto else-label))
+                     (make-a60:label then-label then)
+                     (make-a60:goto cont-label)
+                     (make-a60:label else-label else)
+                     (make-a60:label cont-label (make-a60:dummy))
+                     (cdr l)))))]
+            [(a60:for variable val-exprs body)
+             (let ([body-label (gensym 'for-body)]
+                   [cont-label (gensym 'for-cont)])
+               (letrec ([make-init+test+increment+loop
+                         (lambda (value)
+                           (match value
+                             [(a60:for-number value)
+                              (values (make-a60:assign (list variable) (make-a60:binary 'num 'num
+                                                                                        (->stx '+) 
+                                                                                        (->stx '0)
+                                                                                        value)) ; +0 => number
+                                      (->stx #t)
+                                      (make-a60:dummy)
+                                      #f)]
+                             [(a60:for-step start step end)
+                              (values (make-a60:assign (list variable) start)
+                                      (make-a60:binary 'bool 'num
+                                                       (->stx '<=)
+                                                       (make-a60:binary 'num 'num
+                                                                        (->stx '*)
+                                                                        (make-a60:binary 'num 'num (->stx '-) variable end)
+                                                                        (make-a60:app (->stx 'sign) (list step)))
+                                                       (->stx '0))
+                                      (make-a60:assign (list variable) (make-a60:binary 'num 'num (->stx '+) variable step))
+                                      #t)]
+                             [(a60:for-while value test)
+                              (values (make-a60:assign (list variable) value)
+                                      test
+                                      (make-a60:assign (list variable) value)
+                                      #t)]))])
+                 (if (= 1 (length val-exprs))
+                     (let-values ([(init test inc loop?) (make-init+test+increment+loop (car val-exprs))])
+                       (loop (list*
+                              init
+                              (make-a60:label body-label (make-a60:dummy))
+                              (make-a60:branch test 
+                                               (make-a60:compound
+                                                (list
+                                                 body
+                                                 inc
+                                                 (if loop?
+                                                     (make-a60:goto body-label)
+                                                     (make-a60:dummy))))
+                                               (make-a60:dummy))
+                              (cdr l))))
+                     (let* ([stage-name (datum->syntax #f (gensym 'stage-number))]
+                            [switch-name (datum->syntax #f (gensym 'stage-switch))]
+                            [end-switch-name (datum->syntax #f (gensym 'stage-switch))]
+                            [stage-var (make-a60:variable stage-name null)]
+                            [start-labels (map (lambda (x) (gensym 'stage)) (append val-exprs (list 'extra)))]
+                            [end-labels (map (lambda (x) (gensym 'stage)) val-exprs)])
+                       (set! extra-decls (list* stage-name 
+                                                (cons switch-name start-labels)
+                                                (cons end-switch-name end-labels)
+                                                extra-decls))
+                       (loop
+                        (append
+                         (list (make-a60:assign (list stage-var) (->stx '0)))
+                         (let loop ([start-labels start-labels][end-labels end-labels][val-exprs val-exprs])
+                           (if (null? val-exprs)
+                               (list (make-a60:label (car start-labels) (make-a60:dummy)))
+                               (let-values ([(init test inc loop?) (make-init+test+increment+loop (car val-exprs))])
+                                 (list*
+                                  (make-a60:label (car start-labels) (make-a60:dummy))
+                                  init
+                                  (make-a60:branch test 
+                                                   (make-a60:goto body-label)
+                                                   (make-a60:compound                                                   
+                                                    (list
+                                                     (make-a60:assign (list stage-var) (make-a60:binary 'num 'num
+                                                                                                        (->stx '+)
+                                                                                                        (->stx '1)
+                                                                                                        stage-var))
+                                                     (make-a60:goto (make-a60:subscript switch-name stage-var)))))
+                                  (make-a60:label (car end-labels) (make-a60:dummy))
+                                  inc
+                                  (if loop?
+                                      (make-a60:goto (car start-labels))
+                                      (make-a60:goto (cadr start-labels)))
+                                  (loop (cdr start-labels)
+                                        (cdr end-labels)
+                                        (cdr val-exprs))))))
+                         (list 
                           (make-a60:goto cont-label)
-                          (make-a60:label else-label else)
-                          (make-a60:label cont-label (make-a60:dummy))
-                          (cdr l)))))]
-                 [($ a60:for variable val-exprs body)
-                  (let ([body-label (gensym 'for-body)]
-                        [cont-label (gensym 'for-cont)])
-                    (letrec ([make-init+test+increment+loop
-                              (lambda (value)
-                                (match value
-                                  [($ a60:for-number value)
-                                   (values (make-a60:assign (list variable) (make-a60:binary 'num 'num
-											     (->stx '+) 
-											     (->stx '0)
-											     value)) ; +0 => number
-                                           (->stx #t)
-                                           (make-a60:dummy)
-                                           #f)]
-                                  [($ a60:for-step start step end)
-                                   (values (make-a60:assign (list variable) start)
-                                           (make-a60:binary 'bool 'num
-							    (->stx '<=)
-                                                            (make-a60:binary 'num 'num
-									     (->stx '*)
-                                                                             (make-a60:binary 'num 'num (->stx '-) variable end)
-                                                                             (make-a60:app (->stx 'sign) (list step)))
-                                                            (->stx '0))
-                                           (make-a60:assign (list variable) (make-a60:binary 'num 'num (->stx '+) variable step))
-                                           #t)]
-                                  [($ a60:for-while value test)
-                                   (values (make-a60:assign (list variable) value)
-                                           test
-                                           (make-a60:assign (list variable) value)
-                                           #t)]))])
-                      (if (= 1 (length val-exprs))
-                          (let-values ([(init test inc loop?) (make-init+test+increment+loop (car val-exprs))])
-                            (loop (list*
-                                   init
-                                   (make-a60:label body-label (make-a60:dummy))
-                                   (make-a60:branch test 
-                                                    (make-a60:compound
-                                                     (list
-                                                      body
-                                                      inc
-                                                      (if loop?
-                                                          (make-a60:goto body-label)
-                                                          (make-a60:dummy))))
-                                                    (make-a60:dummy))
-                                   (cdr l))))
-                          (let* ([stage-name (datum->syntax-object #f (gensym 'stage-number))]
-                                 [switch-name (datum->syntax-object #f (gensym 'stage-switch))]
-                                 [end-switch-name (datum->syntax-object #f (gensym 'stage-switch))]
-                                 [stage-var (make-a60:variable stage-name null)]
-                                 [start-labels (map (lambda (x) (gensym 'stage)) (append val-exprs (list 'extra)))]
-                                 [end-labels (map (lambda (x) (gensym 'stage)) val-exprs)])
-                            (set! extra-decls (list* stage-name 
-                                                     (cons switch-name start-labels)
-                                                     (cons end-switch-name end-labels)
-                                                     extra-decls))
-                            (loop
-                             (append
-                              (list (make-a60:assign (list stage-var) (->stx '0)))
-                              (let loop ([start-labels start-labels][end-labels end-labels][val-exprs val-exprs])
-                                (if (null? val-exprs)
-                                    (list (make-a60:label (car start-labels) (make-a60:dummy)))
-                                    (let-values ([(init test inc loop?) (make-init+test+increment+loop (car val-exprs))])
-                                      (list*
-                                       (make-a60:label (car start-labels) (make-a60:dummy))
-                                       init
-                                       (make-a60:branch test 
-                                                        (make-a60:goto body-label)
-                                                        (make-a60:compound                                                   
-                                                         (list
-                                                          (make-a60:assign (list stage-var) (make-a60:binary 'num 'num
-													     (->stx '+)
-													     (->stx '1)
-													     stage-var))
-                                                          (make-a60:goto (make-a60:subscript switch-name stage-var)))))
-                                       (make-a60:label (car end-labels) (make-a60:dummy))
-                                       inc
-                                       (if loop?
-                                           (make-a60:goto (car start-labels))
-                                           (make-a60:goto (cadr start-labels)))
-                                       (loop (cdr start-labels)
-                                             (cdr end-labels)
-                                             (cdr val-exprs))))))
-                              (list 
-                               (make-a60:goto cont-label)
-                               (make-a60:label body-label (make-a60:dummy))
-                               body
-                               (make-a60:goto (make-a60:subscript end-switch-name stage-var))
-                               (make-a60:label cont-label (make-a60:dummy)))
-                              (cdr l)))))))]
-                 [($ a60:label name statement)
-                  (cons (cons name (make-a60:dummy))
-                        (loop (cons statement (cdr l))))]
-                 [else
-                  (cons (cons (gensym 'other) (car l))
-                        (loop (cdr l)))]))))
-       (make-a60:block
-        (append
-         (map (lambda (decl)
-                (match decl
-                  [($ a60:proc-decl result-type var arg-vars by-value-vars arg-specs body)
-                   (make-a60:proc-decl result-type var arg-vars by-value-vars arg-specs
-                                       (simplify-statement body ->stx))]
-                  [else decl]))
-              decls)
-         (map (lambda (extra)
-                (if (identifier? extra)
-                    (make-a60:type-decl (->stx 'integer) (list extra))
-                    (make-a60:switch-decl
-                     (car extra)
-                     (map (lambda (x)
-                            (make-a60:variable (datum->syntax-object #f x)
-                                               null))
-                          (cdr extra)))))
-              extra-decls))
-        (if (null? new-statements)
-            (list (cons (gensym 'other) (make-a60:dummy)))
-            new-statements)))
+                          (make-a60:label body-label (make-a60:dummy))
+                          body
+                          (make-a60:goto (make-a60:subscript end-switch-name stage-var))
+                          (make-a60:label cont-label (make-a60:dummy)))
+                         (cdr l)))))))]
+            [(a60:label name statement)
+             (cons (cons name (make-a60:dummy))
+                   (loop (cons statement (cdr l))))]
+            [else
+             (cons (cons (gensym 'other) (car l))
+                   (loop (cdr l)))]))))
+  (make-a60:block
+   (append
+    (map (lambda (decl)
+           (match decl
+             [(a60:proc-decl result-type var arg-vars by-value-vars arg-specs body)
+              (make-a60:proc-decl result-type var arg-vars by-value-vars arg-specs
+                                  (simplify-statement body ->stx))]
+             [else decl]))
+         decls)
+    (map (lambda (extra)
+           (if (identifier? extra)
+               (make-a60:type-decl (->stx 'integer) (list extra))
+               (make-a60:switch-decl (car extra) (map (lambda (x) 
+                                                        (make-a60:variable (datum->syntax #f x) null)) 
+                                                      (cdr extra)))))
+         extra-decls))
+   (if (null? new-statements)
+       (list (cons (gensym 'other) (make-a60:dummy)))
+       new-statements)))
 
-     (define (simplify stmt ctx)
-       (simplify-statement stmt (lambda (x) (datum->syntax-object ctx x))))
+(define (simplify stmt ctx)
+  (simplify-statement stmt (lambda (x)
+                             (datum->syntax
+                              ctx
+                              x))))
 
-     (define (simplify-statement stmt ->stx)
-       (match stmt
-         [($ a60:block decls statements)
-          (flatten/label-block decls statements ->stx)]
-         [($ a60:compound statements)
-          (flatten/label-block null statements ->stx)]
-         [else stmt])))
+(define (simplify-statement stmt ->stx)
+  (match stmt
+    [(a60:block decls statements)
+     (flatten/label-block decls statements ->stx)]
+    [(a60:compound statements)
+     (flatten/label-block null statements ->stx)]
+    [else stmt]))

--- a/collects/algol60/tool.rkt
+++ b/collects/algol60/tool.rkt
@@ -1,123 +1,122 @@
-(module tool mzscheme
-  (require drscheme/tool
-           mred
-           mzlib/unit
-           mzlib/class
-           "parse.rkt"
-           "simplify.rkt"
-           "compile.rkt"
-           compiler/embed
-           string-constants
-           errortrace/errortrace-lib
-           (prefix bd: "bd-tool.rkt"))
+#lang racket/base
+(require drracket/tool
+         racket/gui
+         racket/unit
+         racket/class
+         "parse.rkt"
+         "simplify.rkt"
+         "compile.rkt"
+         compiler/embed
+         string-constants
+         errortrace/errortrace-lib
+         (prefix-in bd: "bd-tool.rkt"))
 
-  (provide tool@)
+(provide tool@)
 
-  (define base-importing-stx (dynamic-require 'algol60/base
-					      'base-importing-stx))
+(define base-importing-stx (dynamic-require 'algol60/base
+                                            'base-importing-stx))
 
-  (define tool@
-    (unit 
-      (import drscheme:tool^)
-      (export drscheme:tool-exports^)
-      
-      (define-values/invoke-unit bd:tool@
-        (import drscheme:tool^)
-        (export (prefix bd: drscheme:tool-exports^)))
-
-      (define (phase1) (bd:phase1))
-      (define (phase2) 
-	(bd:phase2)
-        (drscheme:language-configuration:add-language
-         (make-object (override-mrflow-methods
-                       ((drscheme:language:get-default-mixin) 
-                        lang%)))))
-      
-      (define (override-mrflow-methods %)
-	(if (method-in-interface? 'render-value-set (class->interface %))
-	    (class %
-	      (inherit [super-render-value-set render-value-set]
-		       [super-get-mrflow-primitives-filename get-mrflow-primitives-filename])
-	      (define/override (render-value-set . x)
-		;; needs to be filled in!
-		(super-render-value-set . x))
-	      (define/override (get-mrflow-primitives-filename)
-		(build-path (collection-path "mrflow")
-			    "primitives"
-			    "algol60.rkt"))
-	      (super-instantiate ()))
-	    %))
-
-      (define lang%
-        (class* object% (drscheme:language:language<%>)
-          (define/public (front-end/finished-complete-program settings) (void))
-          (define/public (extra-repl-information settings port) (void))
-          (define/public (get-reader-module) #f)
-          (define/public (get-metadata a b) #f)
-          (define/public (metadata->settings m) #f)
-          (define/public (get-metadata-lines) #f)
-          
-          (define/public (capability-value s) (drscheme:language:get-capability-default s))
-          (define/public (first-opened) (void))
-          (define/public (config-panel parent)
-            (case-lambda
-              [() null]
-              [(x) (void)]))
-          (define/public (get-comment-character) (values "'COMMENT'" #\*))
-          (define/public (default-settings) null)
-          (define/public (default-settings? x) #t)
-          (define/private (front-end port settings)
-            (let ([name (object-name port)])
-              (lambda ()
-                (if (eof-object? (peek-char port))
-                    eof
-		    (compile-simplified 
-		     (simplify (parse-a60-port port name) base-importing-stx) 
-		     base-importing-stx)))))
-          (define/public (front-end/complete-program port settings) (front-end port settings))
-          (define/public (front-end/interaction port settings) (front-end port settings))
-          (define/public (get-style-delta) #f)
-          (define/public (get-language-position)
-	    (list (string-constant experimental-languages)
-		  "Algol 60"))
-          (define/public (get-language-name) "Algol 60")
-          (define/public (get-language-url) #f)
-          (define/public (get-language-numbers) (list 1000 10))
-          (define/public (get-teachpack-names) null)
-          (define/public (marshall-settings x) x)
-          (define/public (on-execute settings run-in-user-thread)
-            (dynamic-require 'algol60/base #f)
-            (let ([path ((current-module-name-resolver) 'algol60/base #f #f)]
-                  [n (current-namespace)])
-              (run-in-user-thread
-               (lambda ()
-		 (error-display-handler 
-		  (drscheme:debug:make-debug-error-display-handler (error-display-handler)))
-		 (current-compile (make-errortrace-compile-handler))
-                 (with-handlers ([void (lambda (x)
-                                         (printf "~a\n"
-                                                 (exn-message x)))])
-                   (namespace-attach-module n path)
-                   (namespace-require path))))))
-          (define/public (render-value value settings port) (write value port))
-          (define/public (render-value/format value settings port width) (write value port))
-          (define/public (unmarshall-settings x) x)
-	  (define/public (create-executable settings parent src-file)
-	    (let ([dst-file (drscheme:language:put-executable
-			     parent src-file #f #f
-			     (string-constant save-a-mzscheme-stand-alone-executable))])
-	      (when dst-file
-		(let ([code (compile-simplified (simplify (parse-a60-file src-file)
-							  base-importing-stx)
-						base-importing-stx)])
-		  (make-embedding-executable dst-file
-					     #f #f
-					     '((#f algol60/base))
-					     null
-					     (compile
-					      `(module m algol60/base
-						 ,code))
-					     (list "-mvqe" "(require m)"))))))
-	  (define/public (get-one-line-summary) "Of historic interest")
-          
-          (super-instantiate ()))))))
+(define-unit tool@
+    (import drracket:tool^)
+    (export drracket:tool-exports^)
+    
+    (define-values/invoke-unit bd:tool@
+      (import drracket:tool^)
+      (export (prefix bd: drracket:tool-exports^)))
+    
+    (define (phase1) (bd:phase1))
+    (define (phase2) 
+      (bd:phase2)
+      (drracket:language-configuration:add-language
+       (make-object (override-mrflow-methods
+                     ((drracket:language:get-default-mixin) 
+                      lang%)))))
+    
+    (define (override-mrflow-methods %)
+      (if (method-in-interface? 'render-value-set (class->interface %))
+          (class %
+            (inherit [super-render-value-set render-value-set]
+                     [super-get-mrflow-primitives-filename get-mrflow-primitives-filename])
+            (define/override (render-value-set . x)
+              ;; needs to be filled in!
+              (super-render-value-set . x))
+            (define/override (get-mrflow-primitives-filename)
+              (build-path (collection-path "mrflow")
+                          "primitives"
+                          "algol60.rkt"))
+            (super-instantiate ()))
+          %))
+    
+    (define lang%
+      (class* object% (drracket:language:language<%>)
+        (define/public (front-end/finished-complete-program settings) (void))
+        (define/public (extra-repl-information settings port) (void))
+        (define/public (get-reader-module) #f)
+        (define/public (get-metadata a b) #f)
+        (define/public (metadata->settings m) #f)
+        (define/public (get-metadata-lines) #f)
+        
+        (define/public (capability-value s) (drracket:language:get-capability-default s))
+        (define/public (first-opened) (void))
+        (define/public (config-panel parent)
+          (case-lambda
+            [() null]
+            [(x) (void)]))
+        (define/public (get-comment-character) (values "'COMMENT'" #\*))
+        (define/public (default-settings) null)
+        (define/public (default-settings? x) #t)
+        (define/private (front-end port settings)
+          (let ([name (object-name port)])
+            (lambda ()
+              (if (eof-object? (peek-char port))
+                  eof
+                  (compile-simplified 
+                   (simplify (parse-a60-port port name) base-importing-stx) 
+                   base-importing-stx)))))
+        (define/public (front-end/complete-program port settings) (front-end port settings))
+        (define/public (front-end/interaction port settings) (front-end port settings))
+        (define/public (get-style-delta) #f)
+        (define/public (get-language-position)
+          (list (string-constant experimental-languages)
+                "Algol 60"))
+        (define/public (get-language-name) "Algol 60")
+        (define/public (get-language-url) #f)
+        (define/public (get-language-numbers) (list 1000 10))
+        (define/public (get-teachpack-names) null)
+        (define/public (marshall-settings x) x)
+        (define/public (on-execute settings run-in-user-thread)
+          (dynamic-require 'algol60/base #f)
+          (let ([path ((current-module-name-resolver) 'algol60/base #f #f)]
+                [n (current-namespace)])
+            (run-in-user-thread
+             (lambda ()
+               (error-display-handler 
+                (drracket:debug:make-debug-error-display-handler (error-display-handler)))
+               (current-compile (make-errortrace-compile-handler))
+               (with-handlers ([void (lambda (x)
+                                       (printf "~a\n"
+                                               (exn-message x)))])
+                 (namespace-attach-module n path)
+                 (namespace-require path))))))
+        (define/public (render-value value settings port) (write value port))
+        (define/public (render-value/format value settings port width) (write value port))
+        (define/public (unmarshall-settings x) x)
+        (define/public (create-executable settings parent src-file)
+          (let ([dst-file (drracket:language:put-executable
+                           parent src-file #f #f
+                           (string-constant save-a-mzscheme-stand-alone-executable))])
+            (when dst-file
+              (let ([code (compile-simplified (simplify (parse-a60-file src-file)
+                                                        base-importing-stx)
+                                              base-importing-stx)])
+                (make-embedding-executable dst-file
+                                           #f #f
+                                           '((#f algol60/base))
+                                           null
+                                           (compile
+                                            `(module m algol60/base
+                                               ,code))
+                                           (list "-mvqe" "(require m)"))))))
+        (define/public (get-one-line-summary) "Of historic interest")
+        
+        (super-instantiate ()))))


### PR DESCRIPTION
 Move algol-60 collection from mzscheme to racket lang.

-remove mzlib and mzscheme imports
-Make algol60 a racket tool.
-Update the encoded program to be a drracket tool. What a puzzle.
-Small cleanups.
-Ensure tests pass.
-Small indentation fixes