### PR TITLE
Simplified browser configuration for MacOS X

### DIFF
--- a/pkgs/net-lib/net/sendurl.rkt
+++ b/pkgs/net-lib/net/sendurl.rkt
@@ -6,7 +6,7 @@
 (require racket/system racket/file racket/promise racket/port)
 
 (provide send-url send-url/file send-url/contents
-         unix-browser-list browser-preference? external-browser)
+         send-url/mac unix-browser-list browser-preference? external-browser)
 
 (define separate-by-default?
   ;; internal configuration, 'browser-default lets some browsers decide
@@ -156,8 +156,12 @@
     (send-url/file temp)))
 
 (define osascript (delay/sync (find-executable-path "osascript" #f)))
-(define (send-url/mac url)
-  (browser-run (force osascript) "-e" (format "open location \"~a\"" url)))
+(define (send-url/mac url #:browser [browser #f])
+  (browser-run (force osascript) "-e"
+               (if browser
+                   (format "tell application \"~a\" to open location \"~a\""
+                           browser url)
+                   (format "open location \"~a\"" url))))
 
 (define (send-url/unix url separate-window?)
   ;; in cases where a browser was uninstalled, we might get a preference that


### PR DESCRIPTION
Add an optional #:browser argument to send-url/mac and export it.

This makes it straightforward to use different browsers and/or to
configure a different one:

```racket
(require net/sendurl)
(external-browser (lambda (url) (send-url/mac url #:browser "Conkeror")))
```