### PR TITLE
Expose the mk-rhs function normalize-definition uses.

### DIFF
--- a/pkgs/racket-pkgs/racket-doc/syntax/scribblings/define.scrbl
+++ b/pkgs/racket-pkgs/racket-doc/syntax/scribblings/define.scrbl
@@ -38,13 +38,13 @@ expr]] are allowed, and they are preserved in the expansion.}
                                       [err-no-body? boolean?])
          (values identifier? (-> syntax? syntax?) syntax?)]{
 
-  the helper for @racket[normalize-definition] that produces three values:
+  The helper for @racket[normalize-definition] that produces three values:
   the defined identifier, a function that takes the syntax of the body
   and produces syntax that has the expected binding structure, and
   finally the right-hand side expression that @racket[normalize-definition]
   gives to the previous function.
 
   If @racket[err-no-body?] is true, then there must be a right-hand side
-  expression or else it is a syntax error. This is true for uses of
-  @racket[normalize-definition].
+  expression or else it is a syntax error. The @racket[err-no-body?] argument
+  is true for uses of @racket[normalize-definition].
 }

--- a/pkgs/racket-pkgs/racket-doc/syntax/scribblings/define.scrbl
+++ b/pkgs/racket-pkgs/racket-doc/syntax/scribblings/define.scrbl
@@ -30,3 +30,21 @@ an expression context. The default value of @racket[check-context?] is
 If @racket[opt-kws?] is @racket[#t], then arguments of the form
 @racket[[id expr]], @racket[keyword id], and @racket[keyword [id
 expr]] are allowed, and they are preserved in the expansion.}
+
+@defproc[(normalize-definition/mk-rhs [defn-stx syntax?]
+                                      [lambda-id-stx identifier?]
+                                      [check-context? boolean?]
+                                      [opt+kws? boolean?]
+                                      [err-no-body? boolean?])
+         (values identifier? (-> syntax? syntax?) syntax?)]{
+
+  the helper for @racket[normalize-definition] that produces three values:
+  the defined identifier, a function that takes the syntax of the body
+  and produces syntax that has the expected binding structure, and
+  finally the right-hand side expression that @racket[normalize-definition]
+  gives to the previous function.
+
+  If @racket[err-no-body?] is true, then there must be a right-hand side
+  expression or else it is a syntax error. This is true for uses of
+  @racket[normalize-definition].
+}

--- a/racket/collects/syntax/define.rkt
+++ b/racket/collects/syntax/define.rkt
@@ -1,3 +1,3 @@
 (module define racket/base
   (require racket/private/norm-define)
-  (provide normalize-definition))
+  (provide normalize-definition normalize-definition/mk-rhs))

--- a/racket/collects/syntax/doc.txt
+++ b/racket/collects/syntax/doc.txt
@@ -132,6 +132,18 @@ _define.ss_: handling all the same function forms as `define'
   `keyword id', and `keyword [id expr]' are allowed, and they are
   preserved in the expansion.
 
+> (normalize-definition/mk-rhs defn-stx lambda-id-stx [check-context? opt+kws? err-no-body?]) -
+
+  the helper for `normalize-definition' that produces three values:
+  the defined identifier, a function that takes the syntax of the body
+  and produces syntax that has the expected binding structure, and
+  finally the right-hand side expression that `normalize-definition'
+  gives to the previous function.
+
+  If `err-no-body?' is true, then there must be a right-hand side
+  expression or else it is a syntax error. This is true for uses of
+  `normalize-definition'.
+
 ======================================================================
 _struct.ss_: generating the same names as `define-struct'
 ======================================================================


### PR DESCRIPTION
I found I wanted this to make a define/stub macro that errors giving the defined identifier:

```
(define-syntax (define/stub stx)
  (syntax-case stx ()
    [(_ header)
     (let-values ([(id mk-rhs body) (normalize-definition/mk-rhs stx #'lambda #t #t #f)])
       #`(define #,id #,(mk-rhs #`(error '#,id "TODO: stub"))))]))
```