### PR TITLE
New Indentation Rules Implemented

### DIFF
--- a/pkgs/gui-pkgs/gui-lib/scribble/private/indentation.rkt
+++ b/pkgs/gui-pkgs/gui-lib/scribble/private/indentation.rkt
@@ -186,6 +186,7 @@
         (for/first ([start-skip-space (in-range (sub1 para-end) para-start -1)];;ignore the newline
                     #:when (not (member (send txt get-character start-skip-space)  (list #\space #\tab))))
           start-skip-space))))
+;;TODO: start-skip-spaces return false, test cases
 
 ;;(delete-end-spaces a-racket:text para) → void?
 ;;para : exact-integer? = paragraph(line) number
@@ -208,15 +209,47 @@
 
 ;;(count-parens a-racket:text posi) → exact-integer?
 ;;posi : exact-integer? = a position in given text 
-;;Return number of parenthesis till the outmost @ annotation
+;;Return number of parenthesis till the outmost @ annotation,
+;;if the there is "[", we check if it has "@" after at the same
+;;line, if so, we add the number of characters between "[" and
+;;the beginning of the line it appears
 (define (count-parens txt posi)
   (define count 0)
   (do ([p posi (send txt find-up-sexp p)]);backward-containing-sexp p 0)])
     ((not p) count)
-    (begin
-      (when (or (equal? #\{ (send txt get-character p))
-                (equal? #\[ (send txt get-character p)))
-        (set! count (add1 count))))))
+    (cond [(equal? #\{ (send txt get-character p)) (set! count (add1 count))]
+          [(equal? #\[ (send txt get-character p))
+           (let* ([this-para (send txt position-paragraph p)]
+                  [this-para-start (send txt paragraph-start-position this-para)])
+             (if (rest-empty? txt this-para p)
+                 (set! count (add1 count))
+                 (set! count (+ (add1 (- p this-para-start)) count))))]
+          [else #t])))
+
+;;(push-back-check? a-racket:text posi) → Boolean?
+;;posi : exact-integer? = a position in given text which is the @'s position 
+;;Return #f if we see:
+;; 1) "[" with muptiple lines after
+;; 2) keyworld "codeblock" or "verbatim"
+;; otherwise return #t
+(define (push-back-check? t posi)
+  (define key-words (list "codeblock" "verbatim"))
+  (if (is-at-sign? t posi)
+      (let* ([first-char-posi (add1 posi)]
+             [open-paren-posi (send t get-forward-sexp first-char-posi)]);start from the first char after @
+        (cond 
+          [(equal? #\[ (send t get-character open-paren-posi))
+           (let* ([close-paren-posi (sub1 (send t get-forward-sexp open-paren-posi))]
+                  [start-line (send t position-paragraph open-paren-posi)]
+                  [end-line (send t position-paragraph close-paren-posi)])
+             (equal? start-line end-line))]
+          [(equal? #\{ (send t get-character open-paren-posi))
+           (define key-word (send t get-text first-char-posi open-paren-posi))
+           (if (member key-word key-words)
+               #f
+               #t)]
+          [else #f]))
+      #t)) ;; e.g @verbatim|{}|
 
 ;;(push-back-line a-racket:text para width) → void?
 ;;para : exact-integer? = paragraph(line) number
@@ -224,18 +257,18 @@
 ;;width : exact-intefer? = predefined paragrah width
 (define (push-back-lines txt para para-start width)
   (let* ([para-end (send txt paragraph-end-position para)]
-         [new-width (add1 (- para-end para-start))]
+         [new-width (add1 (- para-end para-start))];;init with original line length
          [nxt-para (add1 para)]
          [nxt-para-end (send txt paragraph-end-position nxt-para)])
     (if (or (equal? para-end nxt-para-end) (equal? para-end (sub1 nxt-para-end))) ;;reach/exceed the last line
         #t;;all done
         (let* ([nxt-para-start (start-skip-spaces txt nxt-para 'forward)] 
                [nxt-para-classify (txt-position-classify txt nxt-para-start nxt-para-end)])
-          (unless (is-at-sign? txt nxt-para-start) ;we do not touch @ 
-            ;(when next paragrah(line)'s first non space character is @)
-            (if (and (para-not-empty? nxt-para-classify) (equal? (car nxt-para-classify) 'text) 
+          (unless (not nxt-para-start) ;next line empty, start-skip-spaces returns #f
+            (if (and (para-not-empty? nxt-para-classify) (push-back-check? txt nxt-para-start)
+                     (equal? (send txt classify-position (sub1 para-end)) 'text);;previous line end with text 
                      (< new-width width))
-                ;;we only push back those lines begines with 'text
+                ;;we only push back those lines satisfy push-back-check rules
                 (begin (delete-end-spaces txt para)
                        (delete-start-spaces txt nxt-para)
                        (let ([new-nxt-start (send txt paragraph-start-position nxt-para)])
@@ -431,7 +464,7 @@
   (define txt_8 (new racket:text%))
   (send txt_8 insert "@a{me}\n@b[\n@c{@d{e} f\ng\nh}\n")
   (check-equal? (count-parens txt_8 22) 2)
-  (check-equal? (count-parens txt_8 14) 2)
+  (check-equal? (count-parens txt_8 13) 2);;include current parenthesis
   (check-equal? (determine-spaces txt_8 22) 2)
   (check-equal? (determine-spaces txt_8 12) 1) 
   
@@ -441,6 +474,15 @@
   (check-equal? (indent-racket-func txt_9 6) #f)
   (check-equal? (determine-spaces txt_9 13) #f) 
   (check-equal? (determine-spaces txt_9 4) 1)
+  
+  ;;two test cases for count-parens
+  (check-equal? (let ([t (new racket:text%)])
+                  (send t insert "@a[@b{c d\ne f g}\n@h{i j}]")
+                  (count-parens t 5)) 4)
+  
+  (check-equal? (let ([t (new racket:text%)])
+                  (send t insert "@a[@b{\n@c{d e f}\ng}]")
+                  (count-parens t 9)) 5)
   
   (check-equal? (let ([t (new racket:text%)])
                   (send t insert "(d f\n(l [()\n(f ([a (b c)])\n(d e)))])")
@@ -490,6 +532,38 @@
                   (adjust-spaces t 1 1 4)
                   (adjust-spaces t 1 1 4)
                   (send t get-text)) "@a[\n ]\n")
+  ;;push-back-check?
+  (check-equal? (let ([t (new racket:text%)])
+                  (send t insert "#lang scribble/base\n@test[@a{}]\n")
+                  (push-back-check? t 20))
+                #t)
+  
+  (check-equal? (let ([t (new racket:text%)])
+                  (send t insert "#lang scribble/base\n@test[@a{}\n@b{}]\n")
+                  (push-back-check? t 20))
+                #f)
+  
+  (check-equal? (let ([t (new racket:text%)])
+                  (send t insert "#lang scribble/base\n @test{}\n@test{}\n")
+                  (push-back-check? t 21))
+                #t)
+  
+  (check-equal? (let ([t (new racket:text%)])
+                  (send t insert "#lang scribble/base\n@codeblockfake{}\n")
+                  (push-back-check? t 20))
+                #t)
+  
+  
+  (check-equal? (let ([t (new racket:text%)])
+                  (send t insert "#lang scribble/base\n\n@codeblock{}\n")
+                  (push-back-check? t 21))
+                #f)
+  
+  
+  (check-equal? (let ([t (new racket:text%)])
+                  (send t insert "#lang scribble/base\n@verbatim{}\n")
+                  (push-back-check? t 20))
+                #f)
   
   ;;push-back-lines
   (check-equal? (let ([t (new racket:text%)])
@@ -517,6 +591,24 @@
                 "#lang scribble/base\ntest1 test2 test3\n")
   
   ;;paragraph indentation
+  (check-equal? (let ([t (new racket:text%)])
+                  (send t insert "#lang scribble/base\n\naaa bbb ccc\n  @ddd[eee] fff\n ggg hhh iii jjj\n")
+                  (paragraph-indentation t 23 23)
+                  (send t get-text))
+                "#lang scribble/base\n\naaa bbb ccc @ddd[eee]\nfff ggg hhh iii jjj\n")
+  
+  (check-equal? (let ([t (new racket:text%)])
+                  (send t insert "#lang scribble/base\n\n@itemlist[@item{aaa bbb ccc\n                eee fff}\n          @item{ggg hhh iii\n  jjj kkk lll mmm nnn ooo\n  ppp qqq\nrrr\nsss ttt uuu vvv}]")
+                  (paragraph-indentation t 38 29)
+                  (send t get-text))
+                "#lang scribble/base\n\n@itemlist[@item{aaa bbb ccc\n           eee fff}\n          @item{ggg hhh iii\n           jjj kkk lll mmm\n           nnn ooo ppp qqq\n           rrr sss ttt uuu\n           vvv}]")
+  
+  (check-equal? (let ([t (new racket:text%)])
+                  (send t insert "#lang scribble/base\n\n@itemlist[@item{aaa bbb ccc\n                eee fff\n          @item{ggg hhh iii\n  jjj kkk lll mmm nnn ooo\n  ppp qqq\nrrr\nsss ttt uuu vvv}}]")
+                  (paragraph-indentation t 38 29)
+                  (send t get-text))
+                 "#lang scribble/base\n\n@itemlist[@item{aaa bbb ccc\n           eee fff @item{ggg\n            hhh iii jjj kkk\n            lll mmm nnn ooo\n            ppp qqq rrr sss\n            ttt uuu vvv}}]")
+  
   (check-equal? (let ([t (new racket:text%)])
                   (send t insert "#lang scribble/base\naaa bbb\n @ccc ddd")
                   (adjust-para-width t 22 12) 
@@ -597,3 +689,4 @@
 
 (provide determine-spaces adjust-para-width paragraph-indentation
          surrogate%)
+;;sdsdsdsdsdsd

--- a/pkgs/gui-pkgs/gui-lib/scribble/private/indentation.rkt
+++ b/pkgs/gui-pkgs/gui-lib/scribble/private/indentation.rkt
@@ -238,10 +238,13 @@
              [open-paren-posi (send t get-forward-sexp first-char-posi)]);start from the first char after @
         (cond 
           [(equal? #\[ (send t get-character open-paren-posi))
-           (let* ([close-paren-posi (sub1 (send t get-forward-sexp open-paren-posi))]
-                  [start-line (send t position-paragraph open-paren-posi)]
-                  [end-line (send t position-paragraph close-paren-posi)])
-             (equal? start-line end-line))]
+           (let* ([close-paren-posi-plus-one (send t get-forward-sexp open-paren-posi)]
+                  [start-line (send t position-paragraph open-paren-posi)])
+             (if close-paren-posi-plus-one
+                 (let* ([close-paren-posi (sub1 close-paren-posi-plus-one)]
+                        [end-line (send t position-paragraph close-paren-posi)])
+                   (equal? start-line end-line))
+                 #f))]
           [(equal? #\{ (send t get-character open-paren-posi))
            (define key-word (send t get-text first-char-posi open-paren-posi))
            (if (member key-word key-words)
@@ -606,7 +609,7 @@
                   (send t insert "#lang scribble/base\n\n@itemlist[@item{aaa bbb ccc\n                eee fff\n          @item{ggg hhh iii\n  jjj kkk lll mmm nnn ooo\n  ppp qqq\nrrr\nsss ttt uuu vvv}}]")
                   (paragraph-indentation t 38 29)
                   (send t get-text))
-                 "#lang scribble/base\n\n@itemlist[@item{aaa bbb ccc\n           eee fff @item{ggg\n            hhh iii jjj kkk\n            lll mmm nnn ooo\n            ppp qqq rrr sss\n            ttt uuu vvv}}]")
+                "#lang scribble/base\n\n@itemlist[@item{aaa bbb ccc\n           eee fff @item{ggg\n            hhh iii jjj kkk\n            lll mmm nnn ooo\n            ppp qqq rrr sss\n            ttt uuu vvv}}]")
   
   (check-equal? (let ([t (new racket:text%)])
                   (send t insert "#lang scribble/base\naaa bbb\n @ccc ddd")

--- a/pkgs/gui-pkgs/gui-lib/scribble/private/indentation.rkt
+++ b/pkgs/gui-pkgs/gui-lib/scribble/private/indentation.rkt
@@ -186,7 +186,6 @@
         (for/first ([start-skip-space (in-range (sub1 para-end) para-start -1)];;ignore the newline
                     #:when (not (member (send txt get-character start-skip-space)  (list #\space #\tab))))
           start-skip-space))))
-;;TODO: start-skip-spaces return false, test cases
 
 ;;(delete-end-spaces a-racket:text para) → void?
 ;;para : exact-integer? = paragraph(line) number
@@ -689,4 +688,3 @@
 
 (provide determine-spaces adjust-para-width paragraph-indentation
          surrogate%)
-;;sdsdsdsdsdsd


### PR DESCRIPTION
1) Indentation rules applied to count-paren function:
Count number of parenthesis before given position till the outmost '@'
annotation, if the there is '[', we check if it has '@' right after it within the
same line, if so, we add the number of characters between this '[' and the
beginning of the line it appears to the total parenthesis counting
2) Line push back rules:
We do not push back lines begin with '@ that
a) Has keyword 'codeblock' or 'verbatim' after
b) Contains '[' and multiple lines between it and the closing ']'