### PR TITLE
Add aliases to lexical environment

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/env/type-env-structs.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/env/type-env-structs.rkt
@@ -4,21 +4,33 @@
          syntax/id-table
          (except-in "../utils/utils.rkt" env)
          (contract-req)
-         (rep filter-rep type-rep)
+         (rep filter-rep type-rep object-rep)
          (except-in (utils tc-utils) make-env))
 
 ;; types is a free-id-table of identifiers to types
 ;; props is a list of known propositions
-(define-struct/cond-contract env ([types immutable-free-id-table?] [props (listof Filter/c)])
+;; objs is a free-id-table of identifiers to paths
+;;
+;; objs represents variables which alias another variable (or a subpart of one).
+;; Some paths in objs point at an identifier in types, others point at identifiers in the module level
+;; environment.
+(define-struct/cond-contract env
+  ([types immutable-free-id-table?]
+   [props (listof Filter/c)]
+   [objs immutable-free-id-table?])
   #:transparent
   #:property prop:custom-write
   (lambda (e prt mode)
-    (fprintf prt "(env ~a ~a)" (free-id-table-map (env-types e) list) (env-props e))))
+    (fprintf prt "~a"
+      (list 'env
+        (free-id-table-map (env-types e) list)
+        (env-props e)
+        (free-id-table-map (env-objs e) list)))))
 
 (provide/cond-contract
   [env? predicate/c]
-  [extend (env? identifier? Type/c . -> . env?)]
-  [extend/values (env? (listof identifier?) (listof Type/c) . -> . env?)]
+  [refine (env? identifier? Type/c . -> . env?)]
+  [extend/values (env? (listof identifier?) (listof Type/c) (listof Object/c) . -> . env?)]
   [lookup (env? identifier? (identifier? . -> . any) . -> . any)]
   [env-props (env? . -> . (listof Filter/c))]
   [replace-props (env? (listof Filter/c) . -> . env?)]
@@ -27,28 +39,53 @@
 (define empty-prop-env
   (env
     (make-immutable-free-id-table)
-    null))
+    null
+    (make-immutable-free-id-table)))
 
 
 (define (replace-props e props)
   (match e
-    [(env tys _)
-     (env tys props)]))
+    [(env tys _ objs)
+     (env tys props objs)]))
 
 (define (lookup e key fail)
   (match e
-    [(env tys _) (free-id-table-ref tys key (λ () (fail key)))]))
+    [(env tys _ objs)
+     ;; TODO: Support all paths
+     (match-define (Path: (list) root-id)
+       (free-id-table-ref objs key (make-Path null key)))
+     ;; Since we only support the trivial path we do not need to do any work on the type.
+     (free-id-table-ref tys root-id (λ () (fail root-id)))]))
 
 
-;; extend that works on single arguments
-(define (extend e k v)
-  (extend/values e (list k) (list v)))
-
-;; takes two lists of identifiers and types to be added
-(define (extend/values e ks vs)
+;; Refine an identifier to a specific type.
+(define (refine e id ty)
   (match e
-    [(env tys p)
+    [(env tys p objs)
+     ;; TODO: Support all paths
+     (match-define (Path: (list) root-id)
+       (free-id-table-ref objs id (make-Path null id)))
+     ;; Since we only support the trivial path we do not need to do any work on the type.
+     (env (free-id-table-set tys root-id ty) p objs)]))
+
+;; takes three lists: the identifiers, types, and objects to be added
+(define (extend/values e ks vs os)
+  ;; TODO: Support all paths
+  (define (simple-path? o)
+    (match o
+      [(Path: (list) _) #t]
+      [_ #f]))
+  (match e
+    [(env tys p objs)
      (env
-       (for/fold ([tys tys]) ([k (in-list ks)] [v (in-list vs)])
-         (free-id-table-set tys k v))
-       p)]))
+       (for/fold ([tys tys]) ([k (in-list ks)] [v (in-list vs)] [o (in-list os)])
+         (match o
+           [(Empty:) (free-id-table-set tys k v)]
+           [(Path: (list) id) (free-id-table-set tys id v)]
+           ;; TODO: Do refinement of the type mapped to id in the cases where we use non simple paths.
+           [(Path: _ _) (free-id-table-set tys k v)]))
+       p
+       (for/fold ([objs objs]) ([k (in-list ks)] [o (in-list os)]
+                                #:when (simple-path? o))
+         (match-define (Path: (list) root-id) o)
+         (free-id-table-set objs k (free-id-table-ref objs root-id o))))]))

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/private/type-annotation.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/private/type-annotation.rkt
@@ -100,7 +100,8 @@
                                [a (in-list anns)] [f (in-list fs)] [o (in-list os)])
                       (cond [a (check-type stx ty a) (tc-result a f o)]
                             ;; mutated variables get generalized, so that we don't infer too small a type
-                            [(is-var-mutated? stx) (tc-result (generalize ty) f o)]
+                            ;; and we don't want them associated with the object of the result
+                            [(is-var-mutated? stx) (tc-result (generalize ty) f -empty-obj)]
                             [else (tc-result ty f o)])))]))))]))
 
 ;; check that e-type is compatible with ty in context of stx

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-expression.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-expression.rkt
@@ -51,11 +51,12 @@
       "Cannot instantiate expression that produces ~a values"
       number))
   (match tc-res
-    [(tc-results: tys fs os)
-     (match tys
-      [(list ty)
-       (ret (list (inst-type ty inst)) fs os)]
-      [_ (error-case (if (null? tys) 0 "multiple"))])]
+    [(tc-result1: ty f _)
+     ;; Do not keep the original object because the new type can conflict
+     ;; with the type of it, and we want a unique type per object.
+     (ret (inst-type ty inst) f -empty-obj)]
+    [(tc-results: tys)
+     (error-case (if (null? tys) 0 "multiple"))]
     [_ (error-case "multiple")]))
 
 

--- a/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/unit-tests/typecheck-tests.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/unit-tests/typecheck-tests.rkt
@@ -1047,8 +1047,7 @@
               (-polydots (z x y) (t:-> (cl->*
                                         ((t:-> x z) (-pair x (-lst x)) . t:-> . (-pair z (-lst z)))
                                         ((list ((list x) (y y) . ->... . z) (-lst x)) ((-lst y) y) . ->... . (-lst z)))
-                                       : -true-filter 
-                                       : (-id-path #'map)))]
+                                       : -true-filter))]
 
         ;; error tests
         [tc-err (+ 3 #f)]
@@ -3132,6 +3131,53 @@
           (define (g x) (f x))
           (error "foo"))
         #:msg #rx"Polymorphic function `f' could not be applied"]
+
+       [tc-err
+        (let ()
+          (: f (All (A) (A -> A)))
+          (define (f y) y)
+          (define g (inst f Boolean))
+          (g 4)
+          ((inst f Number) 5))
+        #:ret (ret -Number)]
+
+       [tc-e
+        (let ()
+          (: x Any)
+          (define x 5)
+          (define y x)
+          (if (number? y)
+              (add1 x)
+              5))
+        -Number]
+
+       [tc-e
+        (let ()
+          (: x Any)
+          (define x 5)
+          (let ([y x])
+            (when (number? y)
+              (add1 x))))
+        (t:Un -Void -Number)]
+
+       [tc-e
+        (let ()
+          (define lst null)
+          (set! lst (cons 'x lst)))
+        -Void]
+
+       [tc-e/t
+        (let ()
+          (: x Integer)
+          (define x 5)
+          (let ()
+            (define y
+              (if (>= x 0)
+                  x
+                  (error 'bad)))
+            y))
+        -Nat]
+
         )
 
   (test-suite


### PR DESCRIPTION
This adds support for aliases to the lexical environment. Currently only support for entire aliases is implemented but the scafolding for support of subparts is there. Subparts would be support for understanding that
in
```
(define x (car y))
(define z (car y))
```
`x` and `z` are aliases of each other, since they both refer to `(make-Path (list (make-CarPE)) #'y)`.