### PR TITLE
Add splicing forms to match, and the glaring omission of match-letrec-values

### DIFF
--- a/pkgs/racket-pkgs/racket-doc/scribblings/reference/match.scrbl
+++ b/pkgs/racket-pkgs/racket-doc/scribblings/reference/match.scrbl
@@ -505,6 +505,25 @@ Like @racket[match-let*], but generalizes @racket[let*-values].}
 
 Like @racket[match-let], but generalizes @racket[letrec].}
 
+@defform[(match-letrec-values ([(pat ...) expr] ...) body ...+)]{
+
+Like @racket[match-let], but generalizes @racket[letrec-values].}
+
+@defform[(splicing-match-let ([pat expr] ...) body ...+)]{
+
+Like @racket[match-let], but generalizes @racket[splicing-let].}
+
+@defform[(splicing-match-let-values ([(pat ...) expr] ...) body ...+)]{
+
+Like @racket[match-let-values], but generalizes @racket[splicing-let-values].}
+
+@defform[(splicing-match-letrec ([pat expr] ...) body ...+)]{
+
+Like @racket[match-letrec], but generalizes @racket[splicing-letrec].}
+
+@defform[(splicing-match-letrec-values ([pat expr] ...) body ...+)]{
+
+Like @racket[match-letrec-values], but generalizes @racket[splicing-letrec-values].}
 
 @defform[(match-define pat expr)]{
 

--- a/pkgs/racket-pkgs/racket-test/tests/match/define-match.rkt
+++ b/pkgs/racket-pkgs/racket-test/tests/match/define-match.rkt
@@ -55,3 +55,9 @@
 
 (check-equal? (list-fun '(1 2 3)) #t)
 (check-equal? (list-fun '(4 5 6)) #f)
+
+(define c 0)
+(define tmp 1)
+(splicing-match-let ([(app (λ _ c) c) tmp])
+   (define out c))
+(check-equal? out c)

--- a/racket/collects/racket/match/legacy-match.rkt
+++ b/racket/collects/racket/match/legacy-match.rkt
@@ -17,5 +17,7 @@
 (define-forms parse/legacy
   match match* match-lambda match-lambda* match-lambda** match-let match-let*
   match-let-values match-let*-values
-  match-define match-define-values match-letrec match/values match/derived match*/derived
+  splicing-match-let splicing-match-let-values
+  splicing-match-letrec splicing-match-letrec-values
+  match-define match-define-values match-letrec match-letrec-values match/values match/derived match*/derived
   define/match)

--- a/racket/collects/racket/match/match.rkt
+++ b/racket/collects/racket/match/match.rkt
@@ -30,6 +30,8 @@
 (define-forms parse
   match match* match-lambda match-lambda* match-lambda** match-let match-let*
   match-let-values match-let*-values
-  match-define match-define-values match-letrec match/values
+  splicing-match-let splicing-match-let-values
+  splicing-match-letrec splicing-match-letrec-values
+  match-define match-define-values match-letrec match-letrec-values match/values
   match/derived match*/derived
   define/match)


### PR DESCRIPTION
This is in response to the not-a-bug all/14701.