### PR TITLE
index-scope.rkt: convert find-user-pkgs-dir to a simple-form-path

### DIFF
--- a/pkgs/racket-index/scribblings/main/private/index-scope.rkt
+++ b/pkgs/racket-index/scribblings/main/private/index-scope.rkt
@@ -8,7 +8,7 @@
   (define p
     (find-relative-path 
      (collection-file-path "index-scope.rkt" "scribblings/main/private")
-     (find-user-pkgs-dir)
+     (simple-form-path (find-user-pkgs-dir))
      #:more-than-root? #t))
   (and (path? p)
        (let loop ([p p])


### PR DESCRIPTION
find-relative-path expects a simple-form-path, but according to the documentation PLTUSERHOME as propagated by find-user-pkgs-dir must only be a complete-path?
Without this building of the documentation fails if PLTUSERHOME contains ".."