### PR TITLE
Correct 'german time format

### DIFF
--- a/racket/collects/racket/date.rkt
+++ b/racket/collects/racket/date.rkt
@@ -118,7 +118,7 @@
                        [(12) "Dezember"]
                        [else ""])
                      " " year)
-               (list ", " hour24 "." minute))]
+               (list ", " hour24 ":" minute))]
       [(irish) 
        (values (list week-day ", " day day-th " " month " " year)
                (list ", " hour12 ":" minute am-pm))]


### PR DESCRIPTION
We separate hour and minute with a colon, not with a period.