### PR TITLE
Add docs of unsafe-fxvector

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/unsafe.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/unsafe.scrbl
@@ -282,6 +282,18 @@ fixnum).}
 
 
 @deftogether[(
+@defproc[(unsafe-fxvector-length [v fxvector?]) fixnum?]
+@defproc[(unsafe-fxvector-ref [v fxvector?] [k fixnum?]) any/c]
+@defproc[(unsafe-fxvector-set! [v fxvector?] [k fixnum?] [x fixnum?]) void?]
+)]{
+
+Unsafe versions of @racket[fxvector-length], @racket[fxvector-ref], and
+@racket[fxvector-set!]. A @tech{fxvector}'s size can never be larger than a
+@tech{fixnum} (so even @racket[fxvector-length] always returns a
+fixnum).}
+
+
+@deftogether[(
 @defproc[(unsafe-flvector-length [v flvector?]) fixnum?]
 @defproc[(unsafe-flvector-ref [v flvector?] [k fixnum?]) any/c]
 @defproc[(unsafe-flvector-set! [v flvector?] [k fixnum?] [x flonum?]) void?]

--- a/pkgs/racket-doc/scribblings/reference/unsafe.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/unsafe.scrbl
@@ -283,7 +283,7 @@ fixnum).}
 
 @deftogether[(
 @defproc[(unsafe-fxvector-length [v fxvector?]) fixnum?]
-@defproc[(unsafe-fxvector-ref [v fxvector?] [k fixnum?]) any/c]
+@defproc[(unsafe-fxvector-ref [v fxvector?] [k fixnum?]) fixnum?]
 @defproc[(unsafe-fxvector-set! [v fxvector?] [k fixnum?] [x fixnum?]) void?]
 )]{
 
@@ -295,7 +295,7 @@ fixnum).}
 
 @deftogether[(
 @defproc[(unsafe-flvector-length [v flvector?]) fixnum?]
-@defproc[(unsafe-flvector-ref [v flvector?] [k fixnum?]) any/c]
+@defproc[(unsafe-flvector-ref [v flvector?] [k fixnum?]) flonum?]
 @defproc[(unsafe-flvector-set! [v flvector?] [k fixnum?] [x flonum?]) void?]
 )]{
 
@@ -422,7 +422,7 @@ but further constrained to consume or produce a fixnum.
 
 @deftogether[(
 @defproc[(unsafe-extflvector-length [v extflvector?]) fixnum?]
-@defproc[(unsafe-extflvector-ref [v extflvector?] [k fixnum?]) any/c]
+@defproc[(unsafe-extflvector-ref [v extflvector?] [k fixnum?]) extflonum?]
 @defproc[(unsafe-extflvector-set! [v extflvector?] [k fixnum?] [x extflonum?]) void?]
 )]{
 

--- a/racket/src/racket/src/number.c
+++ b/racket/src/racket/src/number.c
@@ -1406,7 +1406,8 @@ void scheme_init_unsafe_number(Scheme_Env *env)
                              2, 2);
   SCHEME_PRIM_PROC_FLAGS(p) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_IS_BINARY_INLINED
                                                             | SCHEME_PRIM_IS_UNSAFE_OMITABLE
-                                                            | SCHEME_PRIM_IS_OMITABLE);
+                                                            | SCHEME_PRIM_IS_OMITABLE
+                                                            | SCHEME_PRIM_PRODUCES_FIXNUM);
   scheme_add_global_constant("unsafe-fxvector-ref", p, env);
 
   p = scheme_make_immed_prim(unsafe_fxvector_set, "unsafe-fxvector-set!",


### PR DESCRIPTION
The first commit adds the docs of `unsafe-fxvector`.

The second changes the type of the result of `unsafe-fxvector-ref` from `any/c` to `fixnum?`. It also does the equivalent changes in `unsafe-flvector-ref` and `unsafe-extflvector-ref`. I'm not sure because it's easy (but risky and not very wise) to use the unsafe operations to store anything in a `fxvector` and retrieve it later (if you are lucky and there has been no garbage collection).

The third adds the `SCHEME_PRIM_PRODUCES_FIXNUM` flag to `unsafe-fxvector-ref`.
