### PR TITLE
More tests for extflonum

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ build_script:
 - '"c:\Program Files (x86)\Microsoft Visual Studio 10.0\vc\vcvarsall.bat" x86'
 - echo %cd%
 - nmake win32-in-place PKGS="racket-test-core"
+- nmake win32-base
 
 test_script:
 - echo %cd%

--- a/pkgs/racket-test-core/tests/racket/all.rktl
+++ b/pkgs/racket-test-core/tests/racket/all.rktl
@@ -12,6 +12,7 @@
 (load-in-sandbox "dict.rktl")
 (load-in-sandbox "fixnum.rktl")
 (load-in-sandbox "flonum.rktl")
+(load-in-sandbox "extflonum.rktl")
 (load-in-sandbox "string.rktl")
 
 (load-in-sandbox "async-channel.rktl")

--- a/pkgs/racket-test-core/tests/racket/extflonum.rktl
+++ b/pkgs/racket-test-core/tests/racket/extflonum.rktl
@@ -6,6 +6,17 @@
 (require racket/extflonum
          "for-util.rkt")
 
+; minimal tests for when extflonum are no available
+(test "+inf.t" format "~a" +inf.t)
+(test "-inf.t" format "~a" -inf.t)
+(test "+nan.t" format "~a" +nan.t)
+(test "7.0t0" format "~a" 007.000t000)
+(test "-7.0t0" format "~a" -007.000t000)
+(test #t extflonum? 7.t0)
+(test #f extflonum? 7.0)
+(test #f number? 7.t0)
+(test #t number? 7.0)
+
 (when (extflonum-available?)
   ;; ----------------------------------------
 


### PR DESCRIPTION
This is something between a bug report and a pull request.

Racket has a minimal support to read and write `extflonum`s when the `exflonums`
are not available. In this configuration they use a different path code, so it's
necessary to test this version of the code too.

After these commits I get: 

In Linux (Travis) I get these errors:

    (Section (got expected (call)))
    ((extflonum) ("007.000t000" "7.0t0" (format "~a" 007.000t000)))
    ((extflonum) ("-007.000t000" "-7.0t0" (format "~a" -007.000t000)))

I'm not sure if they are error or strange behavior, but the result is different in Windows.

In Windows 7 (32 bits) with Visual Studio 2008 Express, if I cut the build just after the RacketCGC.exe and Racket.exe appear I get: 

    ((extflonum) ("0.0t0" "+inf.t" (#<procedure:format> "~a" 0.0t0)))
    ((extflonum) ("0.0t0" "-inf.t" (#<procedure:format> "~a" 0.0t0)))
    ((extflonum) ("0.0t0" "+nan.t" (#<procedure:format> "~a" 0.0t0)))

[It should be

    ((extflonum) ("0.0t0" "+inf.t" (#<procedure:format> "~a" +inf.t)))
    ((extflonum) ("0.0t0" "-inf.t" (#<procedure:format> "~a" -inf.t)))
    ((extflonum) ("0.0t0" "+nan.t" (#<procedure:format> "~a" +nan.t)))

But the problem is precisely that the print procedure has a problem.]

The problem disapears after the build is completed. I tried to reproduce the error in AppVeyor but I was unsuccessful. I thought it was a problem with `--no-foreign-libs` but now I now I think it's some kind of configuration after the creation of Racket.exe. (`--only-foreign-libs`?)
