### PR TITLE
Fix a typo in define-cstruct

### DIFF
--- a/racket/collects/ffi/unsafe.rkt
+++ b/racket/collects/ffi/unsafe.rkt
@@ -1627,7 +1627,7 @@
                        [(#:malloc-mode m . rest) 
                         (not malloc-mode)
                         (loop #'rest alignment #'m properties property-bindings no-equal?)]
-                       [(#:alignment m . rest) 
+                       [(#:malloc-mode m . rest) 
                         (err "multiple specifications of #:malloc-mode" (head))]
                        [(#:property) (err "missing property expression for #:property" (head))]
                        [(#:property prop) (err "missing value expression for #:property" (head))]


### PR DESCRIPTION
This prevented correct message to be outputted in the case of multiple `#:malloc-mode` specifications