### PR TITLE
Clarify dynamic-require docs and add examples

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/module-reflect.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/module-reflect.scrbl
@@ -455,7 +455,7 @@ Return @racket[#t] if @racket[compiled-module-code] represents a
                                      module-path-index?)]
                           [provided (or/c symbol? #f 0 void?)]
                           [fail-thunk (-> any) (lambda () ....)])
-         any]{
+         (or/c void? any/c)]{
 
 Dynamically @tech{instantiates} the module specified by @racket[mod]
 in the current namespace's registry at the namespace's @tech{base
@@ -472,11 +472,14 @@ above the @tech{base phase}.
 
 When @racket[provided] is a symbol, the value of the module's export
 with the given name is returned, and still the module is not
-@tech{visit}ed or made @tech{available} in higher phases. If the
-module exports @racket[provided] as syntax, then a use of the binding
+@tech{visit}ed or made @tech{available} in higher phases.
+
+If the module exports @racket[provided] as syntax, then a use of the binding
 is expanded and evaluated in a fresh namespace to which the module is
 attached, which means that the module is @tech{visit}ed in the fresh
-namespace. If the module has no such exported variable or syntax, then
+namespace. The expanded syntax must return a single value.
+
+If the module has no such exported variable or syntax, then
 @racket[fail-thunk] is called; the default @racket[fail-thunk] raises
 @racket[exn:fail:contract]. If the variable named by @racket[provided]
 is exported protected (see @secref["modprotect"]), then the

--- a/pkgs/racket-doc/scribblings/reference/module-reflect.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/module-reflect.scrbl
@@ -4,6 +4,8 @@
 
 @title{Module Names and Loading}
 
+@(define mod-eval (make-base-eval))
+
 @;------------------------------------------------------------------------
 @section[#:tag "modnameresolver"]{Resolving Module Names}
 
@@ -470,14 +472,36 @@ and the module is not @tech{visit}ed (see @secref["mod-parse"]) or
 even made @tech{available} (for on-demand @tech{visits}) in phases
 above the @tech{base phase}.
 
+@examples[#:eval mod-eval
+  (module a racket/base (displayln "hello"))
+  (dynamic-require ''a #f)
+]
+
 When @racket[provided] is a symbol, the value of the module's export
 with the given name is returned, and still the module is not
 @tech{visit}ed or made @tech{available} in higher phases.
+
+@examples[#:eval mod-eval
+  (module b racket/base
+    (provide dessert)
+    (define dessert "gulab jamun"))
+  (dynamic-require ''b 'dessert)
+]
 
 If the module exports @racket[provided] as syntax, then a use of the binding
 is expanded and evaluated in a fresh namespace to which the module is
 attached, which means that the module is @tech{visit}ed in the fresh
 namespace. The expanded syntax must return a single value.
+
+@examples[#:eval mod-eval
+  (module c racket/base
+    (require (for-syntax racket/base))
+    (provide dessert2)
+    (define dessert "nanaimo bar")
+    (define-syntax dessert2
+      (make-rename-transformer #'dessert)))
+  (dynamic-require ''c 'dessert2)
+]
 
 If the module has no such exported variable or syntax, then
 @racket[fail-thunk] is called; the default @racket[fail-thunk] raises
@@ -570,3 +594,5 @@ the running Racket instance. Predefined modules always have a symbolic
 resolved module path, and they may be predefined always or
 specifically within a particular executable (such as one created by
 @exec{raco exe} or @racket[create-embedding-executable]).}
+
+@(close-eval mod-eval)


### PR DESCRIPTION
The current docs for `dynamic-require` imply that the function may return multiple values if the binding is defined as syntax and if the syntax expands to multiple values.

It turns out that the implementation restricts the evaluation to a single value. I've adjusted the docs to specify that explicitly, which I think makes more sense than changing the behavior of the function.