### PR TITLE
Add a contract combinator for prefab structs

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/contracts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/contracts.scrbl
@@ -591,6 +591,49 @@ inspect the entire tree.
 @history[#:changed "6.0.1.6" @elem{Added @racket[#:inv].}]
 }
 
+@defproc[(prefab/c [key prefab-key?] [field contract?] ...)
+         contract?]{
+  Produces a contract that recognizes instances of the @tech{prefab}
+  structure type corresponding to @racket[key]. See @racket[make-prefab-struct]
+  for a description of valid key shapes. The number of @racket[field]
+  contracts provided must be consistent with the provided @racket[key].
+
+  @examples[#:eval (contract-eval)
+    (prefab/c 'foo integer?)
+    (prefab/c '(foo bar 1) integer?)
+    (prefab/c '(foo 3) integer? string?)
+  ]
+
+  Each @racket[field] contract is applied to an instance's fields in
+  the same order as the order in the printed form of a prefab struct.
+  That is, the parent fields come before the child fields and auto-value
+  fields come after the ordinary fields.
+
+  The contract will detect if @racket[key] corresponds to a struct
+  type with mutable fields and check field contracts on mutation appropriately.
+  Impersonator contracts are only allowed on fields that are mutable.
+
+  @examples[#:eval (contract-eval)
+    (struct band (members) #:prefab)
+    (define/contract some-band
+      (prefab/c 'band (listof string?))
+      (band (list "Paddy" "Martin")))
+    (struct band/year band (year) #:prefab)
+    (define/contract some-other-band
+      (prefab/c '(band/year 1 band 1) (listof string?) integer?)
+      (band/year (list "Shen" "Micro") 2005))
+  ]
+
+  The contract is a flat contract if all of the @racket[field]
+  contracts are flat contracts and @racket[key] describes a prefab
+  struct type that has no mutable fields. The contract is a
+  chaperone contract if all of the @racket[field] contracts are
+  chaperone contracts. Otherwise the contract that is produced
+  is an impersonator contract.
+
+  @history[#:added "6.1.1.8"]
+}
+
 @defproc[(parameter/c [in contract?] [out contract? in])
          contract?]{
 

--- a/pkgs/racket-test/tests/racket/contract/prefab.rkt
+++ b/pkgs/racket-test/tests/racket/contract/prefab.rkt
@@ -1,0 +1,153 @@
+#lang racket/base
+(require "test-util.rkt")
+
+(parameterize ([current-contract-namespace (make-basic-contract-namespace)])
+  (test/spec-passed
+   'prefab/flat-1
+   '(contract (prefab/c 'foo integer? string?)
+              #s(foo 3 "foo")
+              'pos
+              'neg))
+
+  (test/pos-blame
+   'prefab/flat-2
+   '(contract (prefab/c 'foo integer? string?)
+              #s(foo "foo" 3)
+              'pos
+              'neg))
+
+  (test/pos-blame
+   'prefab/flat-3
+   '(contract (prefab/c '(foo 2 bar 0) integer? string?)
+              #s(foo "foo" 3)
+              'pos
+              'neg))
+
+  (test/pos-blame
+   'prefab/flat-4
+   '(contract (prefab/c 'foo integer? string?)
+              #s((foo 2 bar 0) "foo" 3)
+              'pos
+              'neg))
+
+  (test/spec-passed
+   'prefab/flat-5
+   '(contract (prefab/c 'foo integer? string?)
+              #s((bar 0 foo 2) 3 "foo")
+              'pos
+              'neg))
+
+  (test/spec-passed
+   'prefab/flat-6
+   '(contract (prefab/c '(bar 0 (0 "hello") foo 2 (0 #f)) integer? string?)
+              #s((bar 0 foo 2) 3 "foo")
+              'pos
+              'neg))
+
+  (test/pos-blame
+   'prefab/flat-7
+   '(contract (prefab/c '(foo 2 (1 'def)) integer? string? symbol?)
+              #s((foo 2 (0 'def)) "foo" 3)
+              'pos
+              'neg))
+
+  (test/spec-passed
+   'prefab/flat-8
+   '(let ()
+      (struct foo ([x #:mutable]) #:prefab)
+      (contract (prefab/c '(foo #(0)) integer?)
+                (foo 3)
+                'pos
+                'neg)))
+
+  (test/pos-blame
+   'prefab/flat-9
+   '(let ()
+      (struct foo ([x #:mutable]) #:prefab)
+      (contract (prefab/c '(foo 1) integer?)
+                (foo 3)
+                'pos
+                'neg)))
+
+  (test/pos-blame
+   'prefab/chap-1
+   '(contract (prefab/c 'foo (-> string? string?))
+              #s(foo "not a function")
+              'pos
+              'neg))
+
+  (test/neg-blame
+   'prefab/chap-2
+   '(let ([prefab (contract (prefab/c 'foo (-> string? string?))
+                            `#s(foo ,(λ (x) x))
+                            'pos
+                            'neg)])
+     ((vector-ref (struct->vector prefab) 1)
+      'not-a-string)))
+
+  (test/spec-passed
+   'prefab/chap-3
+   '(contract (prefab/c 'foo (-> string? string?))
+              `#s(foo ,(λ (x) x))
+              'pos
+              'neg))
+
+  (test/pos-blame
+   'prefab/chap-4
+   '(let ([prefab (contract (prefab/c 'foo (-> string? string?))
+                            `#s(foo ,(λ (x) 0))
+                            'pos
+                            'neg)])
+     ((vector-ref (struct->vector prefab) 1) "foo"))) 
+
+  (test/neg-blame
+   'prefab/chap-5
+   '(let ()
+      (struct foo ([x #:mutable]) #:prefab)
+      (define a-foo (contract (prefab/c '(foo #(0)) integer?)
+                              (foo 3)
+                              'pos
+                              'neg))
+      (set-foo-x! a-foo "not an integer"))) 
+
+  (test/spec-passed
+   'prefab/chap-6
+   '(let ()
+      (struct foo ([x #:mutable]) #:prefab)
+      (define a-foo (contract (prefab/c '(foo #(0)) integer?)
+                              (foo 3)
+                              'pos
+                              'neg))
+      (set-foo-x! a-foo 15)))
+
+  (test/neg-blame
+   'prefab/chap-7
+   '(let ()
+      (struct foo ([x #:mutable]) #:prefab)
+      (define a-foo (contract (prefab/c '(foo #(0)) (-> string? string?))
+                              (foo (λ (x) x))
+                              'pos
+                              'neg))
+      (set-foo-x! a-foo (λ (x) 5))
+      ((foo-x a-foo) "foo")))
+
+  (test/neg-blame
+   'prefab/chap-8
+   '(let ()
+      (struct foo ([x #:mutable]) #:prefab)
+      (define a-foo (contract (prefab/c '(foo #(0)) (-> string? string?))
+                              (foo (λ (x) x))
+                              'pos
+                              'neg))
+      (set-foo-x! a-foo (λ (x) x))
+      ((foo-x a-foo) 5)))
+
+  (test/pos-blame
+   'prefab/chap-9
+   '(let ()
+      (struct foo ([x #:mutable]) #:prefab)
+      (define a-foo (contract (prefab/c '(foo #(0)) (-> string? string?))
+                              (foo (λ (x) 5))
+                              'pos
+                              'neg))
+      ((foo-x a-foo) "foo"))))

--- a/racket/collects/racket/contract/base.rkt
+++ b/racket/collects/racket/contract/base.rkt
@@ -9,6 +9,7 @@
          "private/vector.rkt"
          "private/struct-dc.rkt"
          "private/struct-prop.rkt"
+         "private/prefab.rkt"
          "private/misc.rkt"
          "private/provide.rkt"
          "private/guts.rkt"
@@ -45,7 +46,8 @@
                "private/hash.rkt"
                "private/vector.rkt"
                "private/struct-dc.rkt"
-               "private/struct-prop.rkt")
+               "private/struct-prop.rkt"
+               "private/prefab.rkt")
  (except-out (all-from-out "private/base.rkt")
              current-contract-region)
  (except-out (all-from-out "private/misc.rkt")

--- a/racket/collects/racket/contract/private/prefab.rkt
+++ b/racket/collects/racket/contract/private/prefab.rkt
@@ -1,0 +1,209 @@
+#lang racket/base
+
+;; This module implements contracts for prefab structure types
+
+(provide prefab/c)
+
+(require racket/list
+         "guts.rkt"
+         "blame.rkt"
+         "prop.rkt"
+         "misc.rkt")
+
+(define (prefab/c key . *field-ctcs)
+  (define field-ctcs (coerce-contracts 'prefab/c *field-ctcs))
+  (unless (prefab-key? key)
+    (raise-argument-error 'prefab/c "prefab-key?" key))
+  (define (handle-key-inconsistency exn)
+    (raise-arguments-error 'prefab/c
+                           "mismatch between prefab key and field count"
+                           "prefab key" key
+                           "field count" (length *field-ctcs)))
+  (define struct-type
+    (with-handlers ([exn:fail:contract? handle-key-inconsistency])
+      (prefab-key->struct-type key (length *field-ctcs))))
+  (define mutable?
+    (and (pair? key) (ormap vector? key)))
+  (check-mutable-impersonator-consistency struct-type field-ctcs)
+  (cond [(and (andmap flat-contract? field-ctcs)
+              (not mutable?))
+         (flat-prefab/c key struct-type field-ctcs)]
+        [(andmap chaperone-contract? field-ctcs)
+         (chaperone-prefab/c key struct-type field-ctcs)]
+        [else
+         (impersonator-prefab/c key struct-type field-ctcs)]))
+
+(define (prefab/c-name ctc)
+  (apply build-compound-type-name
+         'prefab/c
+         (base-prefab/c-key ctc)
+         (base-prefab/c-ctcs ctc)))
+
+(define ((prefab/c-proj proxy) ctc)
+  (define instance?
+    (struct-type-make-predicate (base-prefab/c-struct-type ctc)))
+  (define ho-projs
+    (for/list ([ctc (in-list (base-prefab/c-ctcs ctc))])
+      (contract-projection ctc)))
+  (define-values (accessors mutators)
+    (compute-accessors/mutators (base-prefab/c-struct-type ctc)))
+  (λ (blame)
+    (define-values (pos-projs neg-projs)
+      (for/lists (_1 _2) ([proj (in-list ho-projs)])
+        (values (λ (this v) ((proj blame) v))
+                (λ (this v) ((proj (blame-swap blame)) v)))))
+    (define accessor/proj
+      (for/fold ([pairs null])
+                ([accessor (in-list accessors)]
+                 [proj (in-list pos-projs)])
+        (cons accessor (cons proj pairs))))
+    (define mutator/proj
+      (for/fold ([pairs null])
+                ([mutator (in-list mutators)]
+                 [proj (in-list neg-projs)]
+                 #:when mutator)
+        (cons mutator (cons proj pairs))))
+    (λ (val)
+      (unless (contract-first-order-passes? ctc val)
+        (raise-blame-error
+         blame val
+         '(expected: "~s" given: "~e")
+         (contract-name ctc)
+         val))
+      (apply proxy val
+             (append accessor/proj
+                     mutator/proj
+                     (list impersonator-prop:contracted ctc
+                           impersonator-prop:blame blame))))))
+
+(define ((prefab/c-val-first-proj proxy) ctc)
+  (define instance?
+    (struct-type-make-predicate (base-prefab/c-struct-type ctc)))
+  (define ho-projs
+    (map get/build-val-first-projection (base-prefab/c-ctcs ctc)))
+  (define-values (accessors mutators)
+    (compute-accessors/mutators (base-prefab/c-struct-type ctc)))
+  (λ (blame)
+    (define-values (pos-projs neg-projs)
+      (for/lists (_1 _2) ([proj (in-list ho-projs)])
+        (values
+         (λ (neg-party)
+           (λ (pr v) (((proj blame) v) neg-party)))
+         (λ (neg-party)
+           (λ (pr v) (((proj (blame-swap blame)) v) neg-party))))))
+    (λ (val)
+      (cond
+        [(contract-first-order-passes? ctc val)
+         (λ (neg-party)
+           (define accessor/proj
+             (for/fold ([pairs null])
+                       ([accessor (in-list accessors)]
+                        [proj (in-list pos-projs)])
+               (cons accessor (cons (proj neg-party) pairs))))
+           (define mutator/proj
+             (for/fold ([pairs null])
+                       ([mutator (in-list mutators)]
+                        [proj (in-list neg-projs)]
+                        #:when mutator)
+               (cons mutator (cons (proj neg-party) pairs))))
+           (apply proxy val
+                  (append accessor/proj
+                          mutator/proj
+                          (list impersonator-prop:contracted ctc
+                                impersonator-prop:blame blame))))]
+        [else
+         (λ (neg-party)
+           (raise-blame-error
+            blame #:missing-party neg-party
+            val '(expected: "~s" given: "~e")
+            (contract-name ctc)
+            val))]))))
+
+;; Struct-Type -> (Listof Procedure) (Listof (U #f Procedure))
+;; Given a struct type for a prefab, get all of the accessor
+;; and mutator functions in the struct hierarchy in order
+;; (parent first). Fields that are not mutable have #f instead of
+;; a mutator.
+(define (compute-accessors/mutators struct-type)
+  (define-values (_1 init auto ref set immutable parent _6)
+    (struct-type-info struct-type))
+  (define field-count (+ init auto))
+  (define-values (parent-accessors parent-mutators)
+    (if parent
+        (compute-accessors/mutators parent)
+        (values null null)))
+  (define-values (base-accessors base-mutators)
+    (for/lists (_1 _2) ([idx (in-range init)])
+      (values (make-struct-field-accessor ref idx)
+              (and (not (member idx immutable =))
+                   (make-struct-field-mutator set idx)))))
+  (define-values (auto-accessors auto-mutators)
+    (for/lists (_1 _2) ([idx (in-range auto)])
+      (values (make-struct-field-accessor ref idx)
+              #f)))
+  (values (append parent-accessors base-accessors auto-accessors)
+          (append parent-mutators base-mutators auto-mutators)))
+
+;; Struct-Type (Listof Contract) -> Void
+;; Check that impersonator contracts are only specified on mutable fields
+;; Precondition: the ctcs length is consistent with the struct-type
+(define (check-mutable-impersonator-consistency struct-type ctcs)
+  (define-values (_1 init auto _2 _3 immutable parent _4)
+    (struct-type-info struct-type))
+  (define-values (for-parents for-this)
+    (split-at-right ctcs (+ init auto)))
+  (when parent
+    (check-mutable-impersonator-consistency parent for-parents))
+  (for ([(ctc idx) (in-indexed (in-list ctcs))])
+    (when (and (or (member idx immutable =)
+                   ;; is an auto-field index, which are always immutable
+                   (> idx (sub1 init)))
+               (impersonator-contract? ctc))
+      (raise-argument-error 'prefab/c
+                            "a chaperone-contract? for immutable field"
+                            ctc))))
+
+(define (prefab/c-first-order ctc)
+  (define instance?
+    (struct-type-make-predicate (base-prefab/c-struct-type ctc)))
+  (λ (val)
+    (and (instance? val)
+         (for/and (;; skip first elem (the struct name)
+                   [elem (in-vector (struct->vector val) 1)]
+                   [ctc (in-list (base-prefab/c-ctcs ctc))])
+           (contract-first-order-passes? ctc elem)))))
+
+(define (prefab/c-stronger? this that)
+  (and (base-prefab/c? that)
+       (equal? (base-prefab/c-key this)
+               (base-prefab/c-key that))
+       (for/and ([this-ctc (in-list (base-prefab/c-ctcs this))]
+                 [that-ctc (in-list (base-prefab/c-ctcs that))])
+         (contract-stronger? this-ctc that-ctc))))
+
+(struct base-prefab/c (key struct-type ctcs))
+
+(struct flat-prefab/c base-prefab/c ()
+  #:property prop:flat-contract
+  (build-flat-contract-property
+   #:name prefab/c-name
+   #:first-order prefab/c-first-order
+   #:stronger prefab/c-stronger?))
+
+(struct chaperone-prefab/c base-prefab/c ()
+  #:property prop:chaperone-contract
+  (build-chaperone-contract-property
+   #:projection (prefab/c-proj chaperone-struct)
+   #:val-first-projection (prefab/c-val-first-proj chaperone-struct)
+   #:name prefab/c-name
+   #:first-order prefab/c-first-order
+   #:stronger prefab/c-stronger?))
+
+(struct impersonator-prefab/c base-prefab/c ()
+  #:property prop:contract
+  (build-contract-property
+   #:projection (prefab/c-proj impersonate-struct)
+   #:val-first-projection (prefab/c-val-first-proj impersonate-struct)
+   #:name prefab/c-name
+   #:first-order prefab/c-first-order
+   #:stronger prefab/c-stronger?))


### PR DESCRIPTION
The `prefab/c` in this PR matches up with the proposed `Prefab` type in TR and specifies a prefab key and a contract for each of the fields.