### PR TITLE
Allow chaperones for methods in class expressions

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/class.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/class.scrbl
@@ -252,7 +252,7 @@ interface @racket[(class->interface object%)], and is transparent
             public pubment public-final override override-final overment augment augride
             augment-final private abstract inherit inherit/super inherit/inner
             rename-super rename-inner begin lambda case-lambda let-values letrec-values
-            define-values #%plain-lambda)
+            define-values #%plain-lambda chaperone-procedure)
 (class* superclass-expr (interface-expr ...)
   class-clause
   ...)
@@ -314,7 +314,9 @@ interface @racket[(class->interface object%)], and is transparent
   (let-values ([(id) method-procedure] ...+) 
     id)
   (letrec-values ([(id) method-procedure] ...+) 
-    id)])]{
+    id)
+  (chaperone-procedure method-procedure wrapper-proc
+                       . other-args)])]{
 
 Produces a class value.
 

--- a/pkgs/racket-doc/scribblings/reference/class.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/class.scrbl
@@ -2076,6 +2076,18 @@ Produces a contract for an object, where the object is an
 instance of a class that conforms to @racket[class-contract].
 }
 
+@defproc[(make-object/c [method-names (listof symbol?)]
+                        [method-contracts (listof contract?)]
+                        [field-names (listof symbol?)]
+                        [field-contracts (listof contract?)])
+         contract?]{
+Produces a contract for an object, similar to @racket[object/c].
+
+This function provides an alternative method to construct
+@racket[object/c] contracts in order to allow library writers
+to create variants or extensions of object contracts at runtime.
+}
+
 @defform/subs[
 #:literals (field -> ->* ->d)
 

--- a/pkgs/racket-test-core/tests/racket/object.rktl
+++ b/pkgs/racket-test-core/tests/racket/object.rktl
@@ -2055,5 +2055,26 @@
   (void))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Test chaperone-procedure on method definitions
+
+(test #t class? (class object% (public m) (define m (chaperone-procedure (λ (x) x) values))))
+(test #t class? (class object%
+                  (public m)
+                  (define m
+                    (chaperone-procedure (case-lambda [(x) x]) values))))
+(test #t class? (class object%
+                  (public m)
+                  (define m
+                    (let-values ([(m) (chaperone-procedure (λ (x) x) values)])
+                      m))))
+(test #t zero? (send (new (class object%
+                            (super-new)
+                            (public m)
+                            (define m
+                              (let-values ([(m) (chaperone-procedure (λ () 0) values)])
+                                m))))
+                     m))
+
+;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (report-errs)

--- a/pkgs/racket-test/tests/racket/contract/object.rkt
+++ b/pkgs/racket-test/tests/racket/contract/object.rkt
@@ -17,6 +17,13 @@
             'pos
             'neg))
 
+(test/spec-passed
+ 'object/c-first-order-object-3
+ '(contract (make-object/c null null null null)
+            (new object%)
+            'pos
+            'neg))
+
 (test/pos-blame
  'object/c-first-order-method-1
  '(contract (object/c [m (-> any/c number? number?)])
@@ -27,6 +34,13 @@
 (test/spec-passed
  'object/c-first-order-method-2
  '(contract (object/c [m (-> any/c number? number?)])
+            (new (class object% (super-new) (define/public (m x) (add1 x))))
+            'pos
+            'neg))
+
+(test/spec-passed
+ 'object/c-first-order-method-3
+ '(contract (make-object/c '(m) (list (-> any/c number? number?)) null null)
             (new (class object% (super-new) (define/public (m x) (add1 x))))
             'pos
             'neg))
@@ -59,6 +73,13 @@
 (test/spec-passed
  'object/c-first-order-field-2
  '(contract (object/c (field [n number?]))
+            (new (class object% (super-new) (field [n 3])))
+            'pos
+            'neg))
+
+(test/spec-passed
+ 'object/c-first-order-field-3
+ '(contract (make-object/c null null '(n) (list number?))
             (new (class object% (super-new) (field [n 3])))
             'pos
             'neg))
@@ -158,4 +179,42 @@
                       'pos
                       'neg)])
     (set-field! n pre-o #t)
-    (get-field n o))))
+    (get-field n o)))
+
+(test/pos-blame
+ 'object/c-higher-order-field-9
+ '(let* ([pre-o (new (class object% (super-new) (field [n 3])))]
+         [o (contract (make-object/c null null '(n) (list number?))
+                      pre-o
+                      'pos
+                      'neg)])
+    (set-field! n pre-o #t)
+    (get-field n o)))
+
+(test/spec-passed/result
+ 'object/c-field-existence
+ '(send (contract
+         (object/c
+          (field foo bar)
+          (baz (->m integer? integer?)))
+         (new (class object%
+                (super-new)
+                (field (foo 0) (bar 0))
+                (define/public (baz n) n)))
+         'pos 'neg)
+        baz 1)
+ 1)
+
+(test/spec-passed/result
+ 'object/c-field-existence2
+ '(send (contract
+         (object/c
+          (field foo bar)
+          (baz (->m integer? (listof integer?))))
+         (new (class object%
+                (super-new)
+                (field (foo 0) (bar 1))
+                (define/public (baz n) (list foo bar))))
+         'pos 'neg)
+        baz 1)
+ '(0 1)))

--- a/racket/collects/racket/private/class-c-old.rkt
+++ b/racket/collects/racket/private/class-c-old.rkt
@@ -19,7 +19,8 @@
          (struct-out internal-class/c)
          just-check-existence just-check-existence?
          build-internal-class/c internal-class/c-proj
-         class/c-internal-name-clauses)
+         class/c-internal-name-clauses
+         make-object/c)
 
 ;; Shorthand contracts that treat the implicit object argument as if it were
 ;; contracted with any/c.
@@ -1200,6 +1201,31 @@
           string<?
           #:key (compose symbol->string car)))
   (values (map car sorted) (map cdr sorted)))
+
+;; make-object/c : Listof<Symbol> Listof<Contract>
+;;                 Listof<Symbol> Listof<Contract>
+;;                 -> Contract
+;; An external constructor provided in order to allow runtime
+;; construction of object contracts by libraries that want to
+;; implement their own object contract variants
+(define (make-object/c method-names method-contracts
+                       field-names field-contracts)
+  (define (ensure-symbols names)
+    (unless (and (list? names) (andmap symbol? names))
+      (raise-argument-error 'make-object/c "(listof symbol?)" names)))
+  (define (ensure-length names ctcs)
+    (unless (= (length names) (length ctcs))
+      (raise-arguments-error 'make-object/c
+                             "expected the same number of names and contracts"
+                             "names" names
+                             "contracts" ctcs)))
+  (ensure-symbols method-names)
+  (ensure-length method-names method-contracts)
+  (ensure-symbols field-names)
+  (ensure-length field-names field-contracts)
+  (make-base-object/c
+   method-names (coerce-contracts 'make-object/c method-contracts)
+   field-names (coerce-contracts 'make-object/c field-contracts)))
 
 (define (check-object-contract obj methods fields fail)
   (unless (object? obj)

--- a/racket/collects/racket/private/class-internal.rkt
+++ b/racket/collects/racket/private/class-internal.rkt
@@ -632,6 +632,20 @@
                  stx)
                 stx
                 (syntax-local-introduce #'let-))))]
+          [(-#%app -chaperone-procedure expr . rst)
+           (and (free-identifier=? (syntax -#%app)
+                                   (quote-syntax #%plain-app))
+                (or (free-identifier=? (syntax -chaperone-procedure)
+                                       (quote-syntax chaperone-procedure))
+                    (free-identifier=? (syntax -chaperone-procedure)
+                                       (quote-syntax chaperone-procedure))))
+           (with-syntax ([expr (loop #'expr #t name locals)])
+             (syntax-track-origin
+              (rearm
+               (syntax/loc stx (-#%app -chaperone-procedure expr . rst))
+               stx)
+              stx
+              (syntax-local-introduce #'-#%app)))]
           [_else 
            (if can-expand?
                (loop (expand stx locals) #f name locals)

--- a/racket/collects/racket/private/class-internal.rkt
+++ b/racket/collects/racket/private/class-internal.rkt
@@ -62,6 +62,7 @@
            (struct-out exn:fail:object)
            make-primitive-class
            class/c ->m ->*m ->dm case->m object/c instanceof/c
+           make-object/c
            
            ;; "keywords":
            private public override augment


### PR DESCRIPTION
I'd like to propose allowing `chaperone-procedure` around method definitions inside of a `class` expression in addition to the currently allowed method shapes. Since a chaperone only introduces extra errors (modulo side effects in the wrapper function and properties), I think this is a fairly conservative change.

My motivation is to allow TR to add chaperone properties to methods, so that contract combinators in TR can identify whether a given method is defined in typed code or untyped code.

The other commit introduces an alternative `object/c` constructor. I think I've submitted this for review before, so I'm just including it here because I intended to push both commits at once.

@mflatt @rfindler Any thoughts?