### PR TITLE
Fix Ignore fuel in optimize_for_inline

### DIFF
--- a/racket/src/racket/src/optimize.c
+++ b/racket/src/racket/src/optimize.c
@@ -1711,7 +1711,7 @@ Scheme_Object *optimize_for_inline(Optimize_Info *info, Scheme_Object *le, int a
   int nested_count = 0, outside_nested = 0, already_opt = optimized_rator, nonleaf, noapp;
 
   noapp = !app && !app2 && !app3;
-  if ((info->inline_fuel < 0 || noapp) && info->has_nonleaf)
+  if ((info->inline_fuel < 0) && info->has_nonleaf && !noapp)
     return NULL;
 
   /* Move inside `let' bindings, so we can convert ((let (....) proc) arg ...)


### PR DESCRIPTION
In 7f61a685523b0481bd2fe161d72e3f804f75a18b I added a check to ignore the fuel in `optimize_for_inline` when it's used to get a known procedure instead of actually inlining. There are a lot of double and triple negations in the code and I messed up the Boolean algebra. 

I think this fix the problem, but I couldn't make test example.
