### PR TITLE
Fix call to optimize_for_inline in procedure? reduction

### DIFF
--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -2145,6 +2145,53 @@
               (define foo integer?)
               (display #t)))
 
+(test-comp '(lambda ()
+              (let ([is3 (lambda () 3)])
+                (letrec ([g (lambda () 3)]
+                         [is0 (lambda () 0)])
+                  g)))
+           '(lambda ()
+              (let ([is3 (lambda () 3)])
+                (letrec ([g (lambda () (is3))]
+                         [is0 (lambda () 0)])
+                  g))))
+
+(test-comp '(lambda (f)
+              (let ([x (f)])
+                (letrec ([g (lambda () (list x #t))]
+                         [dummy (lambda () 0)])
+                  g)))
+           '(lambda (f)
+              (let ([x (f)])
+                (letrec ([g (lambda () (list x (procedure? x)))]
+                         [dummy (lambda () 0)])
+                  g)))
+           #f)
+
+(test-comp '(lambda (f)
+              (let ([x (f)])
+                (car x)
+                (letrec ([g (lambda () (list x #t))]
+                         [dummy (lambda () 0)])
+                  g)))
+           '(lambda (f)
+              (let ([x (f)])
+                (car x)
+                (letrec ([g (lambda () (list x (pair? x)))]
+                         [dummy (lambda () 0)])
+                  g))))
+
+(test-comp '(lambda (f)
+              (let ([x (f)])
+                (letrec ([g (lambda () (car x) (list x #t))]
+                         [dummy (lambda () 0)])
+                  g)))
+           '(lambda (f)
+              (let ([x (f)])
+                (letrec ([g (lambda () (car x) (list x (pair? x)))]
+                         [dummy (lambda () 0)])
+                  g))))
+
 (test-comp '(module m racket/base
               (void 10))
            '(module m racket/base))
@@ -2188,7 +2235,7 @@
                 (define inlinable-function (lambda (x) (list 1 x 3))))
               (require 'in)
               (lambda () (display (procedure? inlinable-function)) (procedure? inlinable-function))))
-      
+
 (let ([try-equiv
        (lambda (extras)
          (lambda (a b)


### PR DESCRIPTION
If I understand correctly, `optimize_for_inline` assumes that the local reference are in the old coordinates but in the `procedure?` reduction they have the new coordinates, so it's necessary to call `optimize_reverse`.

The first commit includes only the tests, because I'm sure they are correct and they identify the error. (One of them produces an error with the old code, and another produces an error with one of my draft implementations that was "almost" correct.)

The second commit is an attempt to fix this, but I'm not so sure about the details here. Also, this commit removes the additional argument of `optimize_for_inline` that I added in 0c5944d64a07e2cc2ebd8af36d0bd2057541b24c because it was used only here and it was a special case that didn't mix with the other code. Now the shifting is done with the reversing in `finish_optimize_application2`.
