### PR TITLE
Reduce repeated object/c wrapping & modify opaque class/c

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/class.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/class.scrbl
@@ -1785,7 +1785,8 @@ A class contract can be specified to be @emph{opaque} with the @racket[#:opaque]
 keyword. An opaque class contract will only accept a class that defines
 exactly the external methods and fields specified by the contract. A contract error
 is raised if the contracted class contains any methods or fields that are
-not specified.
+not specified. Methods or fields with local member names (i.e., defined with
+@racket[define-local-member-name]) are ignored for this check.
 
 The external contracts are as follows:
 
@@ -2009,7 +2010,10 @@ As with the external contracts, when a method or field name is specified
    such subclasses.}
 
 @history[#:changed "6.1.1.8"
-         "opaque @racket[class/c] now ignores local member names"]
+         @string-append{Opaque @racket[class/c] now ignores local member names.
+                        This is backwards incompatible, but only affects uses of
+                        opaque @racket[class/c] contracts applied to classes
+                        with methods or fields with local names.}]
 ]}
 
 @defform[(absent absent-spec ...)]{

--- a/pkgs/racket-doc/scribblings/reference/class.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/class.scrbl
@@ -2008,6 +2008,8 @@ As with the external contracts, when a method or field name is specified
    checked on any access and/or mutation of the field that occurs in
    such subclasses.}
 
+@history[#:changed "6.1.1.8"
+         "opaque @racket[class/c] now ignores local member names"]
 ]}
 
 @defform[(absent absent-spec ...)]{

--- a/pkgs/racket-doc/scribblings/reference/class.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/class.scrbl
@@ -1737,7 +1737,8 @@ resulting trait are the same as for @racket[trait-sum], otherwise the
 
 ([maybe-opaque
   (code:line)
-  (code:line #:opaque)]
+  (code:line #:opaque)
+  (code:line #:opaque #:ignore-local-member-names)]
 
  [member-spec
   method-spec
@@ -1786,7 +1787,8 @@ keyword. An opaque class contract will only accept a class that defines
 exactly the external methods and fields specified by the contract. A contract error
 is raised if the contracted class contains any methods or fields that are
 not specified. Methods or fields with local member names (i.e., defined with
-@racket[define-local-member-name]) are ignored for this check.
+@racket[define-local-member-name]) are ignored for this check if
+@racket[#:ignore-local-member-names] is provided.
 
 The external contracts are as follows:
 
@@ -2010,10 +2012,8 @@ As with the external contracts, when a method or field name is specified
    such subclasses.}
 
 @history[#:changed "6.1.1.8"
-         @string-append{Opaque @racket[class/c] now ignores local member names.
-                        This is backwards incompatible, but only affects uses of
-                        opaque @racket[class/c] contracts applied to classes
-                        with methods or fields with local names.}]
+         @string-append{Opaque class/c now optionally ignores local
+                        member names if an additional keyword is supplied.}]
 ]}
 
 @defform[(absent absent-spec ...)]{

--- a/pkgs/racket-test/tests/racket/contract/class.rkt
+++ b/pkgs/racket-test/tests/racket/contract/class.rkt
@@ -123,7 +123,7 @@
               'pos
               'neg))
   
-  (test/pos-blame
+  (test/spec-passed
    'class/c-first-order-opaque-method-3
    '(let ()
       (define-local-member-name n)
@@ -132,7 +132,7 @@
                 'pos
                 'neg)))
   
-  (test/pos-blame
+  (test/spec-passed
    'class/c-first-order-opaque-method-4
    '(contract
      (class/c #:opaque [m (-> any/c number? number?)])
@@ -230,7 +230,7 @@
               'pos
               'neg))
   
-  (test/pos-blame
+  (test/spec-passed
    'class/c-first-order-opaque-field-2
    '(contract (class/c #:opaque (field [m number?]))
               (let ()
@@ -489,7 +489,7 @@
               'pos
               'neg))
   
-  (test/pos-blame
+  (test/spec-passed
    'class/c-first-order-opaque-super-3
    '(contract (class/c #:opaque)
               (class (let ()

--- a/pkgs/racket-test/tests/racket/contract/class.rkt
+++ b/pkgs/racket-test/tests/racket/contract/class.rkt
@@ -123,7 +123,7 @@
               'pos
               'neg))
   
-  (test/spec-passed
+  (test/pos-blame
    'class/c-first-order-opaque-method-3
    '(let ()
       (define-local-member-name n)
@@ -131,11 +131,30 @@
                 (class object% (super-new) (define/public (m x) 3) (define/public (n) 4))
                 'pos
                 'neg)))
-  
+
   (test/spec-passed
+   'class/c-first-order-opaque-method-3-ignore
+   '(let ()
+      (define-local-member-name n)
+      (contract (class/c #:opaque #:ignore-local-member-names [m (-> any/c number? number?)])
+                (class object% (super-new) (define/public (m x) 3) (define/public (n) 4))
+                'pos
+                'neg)))
+
+  (test/pos-blame
    'class/c-first-order-opaque-method-4
    '(contract
      (class/c #:opaque [m (-> any/c number? number?)])
+     (let ()
+       (define-local-member-name n)
+       (class object% (super-new) (define/public (m x) 3) (define/public (n) 4)))
+     'pos
+     'neg))
+
+  (test/spec-passed
+   'class/c-first-order-opaque-method-4-ignore
+   '(contract
+     (class/c #:opaque #:ignore-local-member-names [m (-> any/c number? number?)])
      (let ()
        (define-local-member-name n)
        (class object% (super-new) (define/public (m x) 3) (define/public (n) 4)))
@@ -230,9 +249,18 @@
               'pos
               'neg))
   
-  (test/spec-passed
-   'class/c-first-order-opaque-field-2
+  (test/pos-blame
+   'class/c-first-order-opaque-field-3
    '(contract (class/c #:opaque (field [m number?]))
+              (let ()
+                (define-local-member-name n)
+                (class object% (super-new) (field [m 5] [n 3])))
+              'pos
+              'neg))
+
+  (test/spec-passed
+   'class/c-first-order-opaque-field-3-ignore
+   '(contract (class/c #:opaque #:ignore-local-member-names (field [m number?]))
               (let ()
                 (define-local-member-name n)
                 (class object% (super-new) (field [m 5] [n 3])))
@@ -489,9 +517,19 @@
               'pos
               'neg))
   
-  (test/spec-passed
+  (test/pos-blame
    'class/c-first-order-opaque-super-3
    '(contract (class/c #:opaque)
+              (class (let ()
+                       (define-local-member-name m)
+                       (class object% (super-new) (define/public (m) 3)))
+                (super-new))
+              'pos
+              'neg))
+
+  (test/spec-passed
+   'class/c-first-order-opaque-super-3-ignore
+   '(contract (class/c #:opaque #:ignore-local-member-names)
               (class (let ()
                        (define-local-member-name m)
                        (class object% (super-new) (define/public (m) 3)))

--- a/pkgs/racket-test/tests/racket/contract/stronger.rkt
+++ b/pkgs/racket-test/tests/racket/contract/stronger.rkt
@@ -346,6 +346,33 @@
   (ctest #f contract-stronger?
          (instanceof/c (class/c (m (-> any/c (<=/c 4)))))
          (instanceof/c (class/c (m (-> any/c (<=/c 3))))))
+
+  (ctest #t contract-stronger?
+         (object/c (m (-> any/c (<=/c 3))))
+         (object/c (m (-> any/c (<=/c 4)))))
+  (ctest #t contract-stronger?
+         (object/c (field (f (<=/c 4))))
+         (object/c (field (f (<=/c 4)))))
+  (ctest #t contract-stronger?
+         (object/c (m (-> any/c (<=/c 3)))
+                   (n (-> any/c any/c)))
+         (object/c (m (-> any/c (<=/c 4)))))
+  (ctest #f contract-stronger?
+         (object/c (m (-> any/c (<=/c 4))))
+         (object/c (m (-> any/c (<=/c 3)))))
+  (ctest #f contract-stronger?
+         (object/c (field (f (<=/c 4))))
+         (object/c (field (f (<=/c 3)))))
+  (ctest #f contract-stronger?
+         (object/c (m (-> any/c (<=/c 3))))
+         (object/c (n (-> any/c (<=/c 4)))))
+  (ctest #f contract-stronger?
+         (object/c (field (x any/c)))
+         (object/c (field (y any/c))))
+  (ctest #f contract-stronger?
+         (object/c (m (-> any/c (<=/c 4))))
+         (object/c (m (-> any/c (<=/c 3)))
+                   (n (-> any/c any/c))))
   
   (ctest #t contract-stronger? (is-a?/c object%) (is-a?/c object%))
   (ctest #t contract-stronger? (is-a?/c (class object% (super-new))) (is-a?/c object%))

--- a/racket/collects/racket/private/class-c-old.rkt
+++ b/racket/collects/racket/private/class-c-old.rkt
@@ -1202,108 +1202,21 @@
           #:key (compose symbol->string car)))
   (values (map car sorted) (map cdr sorted)))
 
-;; dynamic-object/c : Listof<Symbol> Listof<Contract>
-;;                    Listof<Symbol> Listof<Contract>
-;;                    -> Contract
-;; An external constructor provided in order to allow runtime
-;; construction of object contracts by libraries that want to
-;; implement their own object contract variants
-(define (dynamic-object/c method-names method-contracts
-                          field-names field-contracts)
-  (define (ensure-symbols names)
-    (unless (and (list? names) (andmap symbol? names))
-      (raise-argument-error 'dynamic-object/c "(listof symbol?)" names)))
-  (define (ensure-length names ctcs)
-    (unless (= (length names) (length ctcs))
-      (raise-arguments-error 'dynamic-object/c
-                             "expected the same number of names and contracts"
-                             "names" names
-                             "contracts" ctcs)))
-  (ensure-symbols method-names)
-  (ensure-length method-names method-contracts)
-  (ensure-symbols field-names)
-  (ensure-length field-names field-contracts)
-  (make-base-object/c
-   method-names (coerce-contracts 'dynamic-object/c method-contracts)
-   field-names (coerce-contracts 'dynamic-object/c field-contracts)))
-
-(define (check-object-contract obj methods fields fail)
-  (unless (object? obj)
-    (fail '(expected: "an object" given: "~e") obj))
-  (let ([cls (object-ref/unwrap obj)])
-    (let ([method-ht (class-method-ht cls)])
-      (for ([m methods])
-        (unless (hash-ref method-ht m #f)
-          (fail "no public method ~a" m))))
-    (let ([field-ht (class-field-ht cls)])
-      (for ([m fields])
-        (unless (hash-ref field-ht m #f)
-          (fail "no public field ~a" m)))))
-  #t)
-
-(define (object/c-proj ctc)
-  (λ (blame)
-    (λ (obj)
-      (make-wrapper-object ctc obj blame 
-                           (base-object/c-methods ctc) (base-object/c-method-contracts ctc)
-                           (base-object/c-fields ctc) (base-object/c-field-contracts ctc)))))
-
-(define (object/c-first-order ctc)
-  (λ (obj)
-    (let/ec ret
-      (check-object-contract obj 
-                             (base-object/c-methods ctc) 
-                             (base-object/c-fields ctc)
-                             (λ args (ret #f))))))
-
-(define-struct base-object/c (methods method-contracts fields field-contracts)
-  #:property prop:custom-write custom-write-property-proc
-  #:property prop:contract
-  (build-contract-property 
-   #:projection object/c-proj
-   #:name
-   (λ (ctc)
-     (let* ([pair-ids-ctcs
-             (λ (is ctcs)
-               (map (λ (i ctc)
-                      (build-compound-type-name i ctc))
-                    is ctcs))]
-            [handle-optional
-             (λ (name is ctcs)
-               (if (null? is)
-                   null
-                   (list (cons name (pair-ids-ctcs is ctcs)))))])
-       (apply build-compound-type-name
-              'object/c 
-              (append
-               (pair-ids-ctcs (base-object/c-methods ctc) (base-object/c-method-contracts ctc))
-               (handle-optional 'field 
-                                (base-object/c-fields ctc)
-                                (base-object/c-field-contracts ctc))))))
-   #:first-order object/c-first-order))
-
-(define-syntax (object/c stx)
-  (syntax-case stx ()
-    [(_ form ...)
-     (let ()
-       (define-values (bindings pfs)
-         (parse-class/c-specs (syntax->list #'(form ...)) #t))
-       (with-syntax ([methods #`(list #,@(reverse (hash-ref pfs 'methods null)))]
-                     [method-ctcs #`(list #,@(reverse (hash-ref pfs 'method-contracts null)))]
-                     [fields #`(list #,@(reverse (hash-ref pfs 'fields null)))]
-                     [field-ctcs #`(list #,@(reverse (hash-ref pfs 'field-contracts null)))]
-                     [bindings bindings])
-         (syntax/loc stx
-           (let bindings
-             (make-base-object/c methods method-ctcs fields field-ctcs)))))]))
-
 (define (instanceof/c-proj ctc)
-  (define proj (contract-projection (base-instanceof/c-class-ctc ctc)))
+  (define proj
+    (if (base-instanceof/c? ctc)
+        (contract-projection (base-instanceof/c-class-ctc ctc))
+        (object/c-class-proj ctc)))
   (λ (blame)
     (define p (proj (blame-add-context blame #f)))
     (λ (val)
       (unless (object? val)
         (raise-blame-error blame val '(expected: "an object" given: "~e") val))
+      (when (base-object/c? ctc)
+        (check-object-contract val
+                               (base-object/c-methods ctc)
+                               (base-object/c-fields ctc)
+                               (λ args (apply raise-blame-error blame val args))))
       (define original-obj (if (has-original-object? val) (original-object val) val))
       (define new-cls (p (object-ref val)))
       (cond
@@ -1467,6 +1380,135 @@
 (define (instanceof/c cctc)
   (let ([ctc (coerce-contract 'instanceof/c cctc)])
     (make-base-instanceof/c ctc)))
+
+;; dynamic-object/c : Listof<Symbol> Listof<Contract>
+;;                    Listof<Symbol> Listof<Contract>
+;;                    -> Contract
+;; An external constructor provided in order to allow runtime
+;; construction of object contracts by libraries that want to
+;; implement their own object contract variants
+(define (dynamic-object/c method-names method-contracts
+                          field-names field-contracts)
+  (define (ensure-symbols names)
+    (unless (and (list? names) (andmap symbol? names))
+      (raise-argument-error 'dynamic-object/c "(listof symbol?)" names)))
+  (define (ensure-length names ctcs)
+    (unless (= (length names) (length ctcs))
+      (raise-arguments-error 'dynamic-object/c
+                             "expected the same number of names and contracts"
+                             "names" names
+                             "contracts" ctcs)))
+  (ensure-symbols method-names)
+  (ensure-length method-names method-contracts)
+  (ensure-symbols field-names)
+  (ensure-length field-names field-contracts)
+  (make-base-object/c
+   method-names (coerce-contracts 'dynamic-object/c method-contracts)
+   field-names (coerce-contracts 'dynamic-object/c field-contracts)))
+
+(define (object/c-class-proj ctc)
+  (define methods (base-object/c-methods ctc))
+  (define method-contracts (base-object/c-method-contracts ctc))
+  (define fields (base-object/c-fields ctc))
+  (define field-contracts (base-object/c-field-contracts ctc))
+  (λ (blame)
+    (λ (val)
+      (make-wrapper-class
+       val blame
+       methods method-contracts fields field-contracts))))
+
+(define (check-object-contract obj methods fields fail)
+  (unless (object? obj)
+    (fail '(expected: "an object" given: "~e") obj))
+  (let ([cls (object-ref/unwrap obj)])
+    (let ([method-ht (class-method-ht cls)])
+      (for ([m methods])
+        (unless (hash-ref method-ht m #f)
+          (fail "no public method ~a" m))))
+    (let ([field-ht (class-field-ht cls)])
+      (for ([m fields])
+        (unless (hash-ref field-ht m #f)
+          (fail "no public field ~a" m)))))
+  #t)
+
+(define (object/c-first-order ctc)
+  (λ (obj)
+    (let/ec ret
+      (check-object-contract obj
+                             (base-object/c-methods ctc)
+                             (base-object/c-fields ctc)
+                             (λ args (ret #f))))))
+
+(define (object/c-stronger this that)
+  (cond
+    [(base-object/c? that)
+     (and
+      ;; methods
+      (check-one-object base-object/c-methods base-object/c-method-contracts this that)
+
+      ;; check both ways for fields (since mutable)
+      (check-one-object base-object/c-fields base-object/c-field-contracts this that)
+      (check-one-object base-object/c-fields base-object/c-field-contracts that this)
+
+      ;; width subtyping
+      (all-included? (base-object/c-methods that)
+                     (base-object/c-methods this))
+      (all-included? (base-object/c-fields that)
+                     (base-object/c-fields this)))]
+    [else #f]))
+
+;; See `check-one-stronger`. The difference is that this one only checks the
+;; names that are in both this and that.
+(define (check-one-object names-sel ctcs-sel this that)
+  (for/and ([this-name (in-list (names-sel this))]
+            [this-ctc (in-list (ctcs-sel this))])
+    (or (not (member this-name (names-sel that)))
+        (for/or ([that-name (in-list (names-sel that))]
+                 [that-ctc (in-list (ctcs-sel that))])
+          (and (equal? this-name that-name)
+               (contract-stronger? this-ctc that-ctc))))))
+
+(define-struct base-object/c (methods method-contracts fields field-contracts)
+  #:property prop:custom-write custom-write-property-proc
+  #:property prop:contract
+  (build-contract-property
+   #:projection instanceof/c-proj
+   #:name
+   (λ (ctc)
+     (let* ([pair-ids-ctcs
+             (λ (is ctcs)
+               (map (λ (i ctc)
+                      (build-compound-type-name i ctc))
+                    is ctcs))]
+            [handle-optional
+             (λ (name is ctcs)
+               (if (null? is)
+                   null
+                   (list (cons name (pair-ids-ctcs is ctcs)))))])
+       (apply build-compound-type-name
+              'object/c
+              (append
+               (pair-ids-ctcs (base-object/c-methods ctc) (base-object/c-method-contracts ctc))
+               (handle-optional 'field
+                                (base-object/c-fields ctc)
+                                (base-object/c-field-contracts ctc))))))
+   #:first-order object/c-first-order
+   #:stronger object/c-stronger))
+
+(define-syntax (object/c stx)
+  (syntax-case stx ()
+    [(_ form ...)
+     (let ()
+       (define-values (bindings pfs)
+         (parse-class/c-specs (syntax->list #'(form ...)) #t))
+       (with-syntax ([methods #`(list #,@(reverse (hash-ref pfs 'methods null)))]
+                     [method-ctcs #`(list #,@(reverse (hash-ref pfs 'method-contracts null)))]
+                     [fields #`(list #,@(reverse (hash-ref pfs 'fields null)))]
+                     [field-ctcs #`(list #,@(reverse (hash-ref pfs 'field-contracts null)))]
+                     [bindings bindings])
+         (syntax/loc stx
+           (let bindings
+             (make-base-object/c methods method-ctcs fields field-ctcs)))))]))
 
 ;; make-wrapper-object: contract object blame 
 ;;                      (listof symbol) (listof contract?) (listof symbol) (listof contract?)

--- a/racket/collects/racket/private/class-c-old.rkt
+++ b/racket/collects/racket/private/class-c-old.rkt
@@ -62,9 +62,8 @@
   (when (class/c-opaque? ctc)
     (for ([m (in-hash-keys method-ht)])
       (unless (memq m (class/c-methods ctc))
-        (if (symbol-interned? m)
-            (fail "method ~a not specified in contract" m)
-            (fail "some local member not specified in contract")))))
+        (when (symbol-interned? m)
+          (fail "method ~a not specified in contract" m)))))
   
   (define field-ht (class-field-ht cls))
   (for ([f (class/c-fields ctc)])
@@ -77,9 +76,8 @@
   (when (class/c-opaque? ctc)
     (for ([f (in-hash-keys field-ht)])
       (unless (memq f (class/c-fields ctc))
-        (if (symbol-interned? f)
-            (fail "field ~a not specified in contract" f)
-            (fail "some local member field not specified in contract")))))
+        (when (symbol-interned? f)
+          (fail "field ~a not specified in contract" f)))))
   #t)
 
 (define (internal-class/c-check-first-order internal-ctc cls fail)


### PR DESCRIPTION
This PR combines two object/class contract changes. Both support upcoming Typed Racket changes.

One is adapting `object/c` to use the projection of `instanceof/c` in order to get the space-efficiency benefits of the latter (avoiding exponential wrapping). The motivation is to allow Typed Racket to switch to using `object/c` over `instanceof/c` in more cases.

The second changes opaque `class/c` contracts (i.e., ones where `#:opaque` is specified) to ignore local member names. I think the initial design choice may have been a mistake, since if the module specifying the opaque `class/c` doesn't have access to those local member names, it's impossible to specify a passing contract. This is especially a problem for Typed Racket---it doesn't really make sense to have to specify types for, say, internal GUI class member names which are never meant to be accessed.

@rfindler does this look reasonable?