### PR TITLE
More redutions of predicates

### DIFF
--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -1237,6 +1237,14 @@
            '(lambda (w z) #t)
            #f)
 
+(test-comp '(lambda (w z) (list? (begin (random) null)))
+           '(lambda (w z) (random) #t))
+(test-comp '(lambda (w z) (list? (begin (random) (void))))
+           '(lambda (w z) (random) #f))
+(test-comp '(lambda (w z) (list? (cons w z)))
+           '(lambda (w z) #t)
+           #f)
+
 (test-comp '(lambda (w z)
               (let ([x (list* w z)]
                     [y (list* z w)])

--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -2104,10 +2104,18 @@
                 (letrec ([f (lambda (x) (f x))])
                   f))))
 
-(test-comp '(procedure? add1)
-           #t)
-(test-comp '(procedure? (lambda (x) x))
-           #t)
+(test-comp #t
+           '(procedure? add1))
+(test-comp '(lambda () #t)
+           '(lambda () (procedure? add1)))
+(test-comp #t
+           '(procedure? (lambda (x) x)))
+(test-comp '(lambda () #t)
+           '(lambda () (procedure? (lambda (x) x))))
+(test-comp #f
+           '(pair? (lambda (x) x)))
+(test-comp '(lambda () #f)
+           '(lambda () (pair? (lambda (x) x))))
 (test-comp '(let ([f (lambda (x) x)])
               (if (procedure? f)
                   (list f)
@@ -2134,6 +2142,15 @@
                          [(x y) (f (+ x y))])])
 	      (f 10))
 	   '10)
+
+(test-comp '(lambda (x) #f)
+           '(lambda (x) (pair? (if x car cdr))))
+(test-comp '(lambda (x) #t)
+           '(lambda (x) (procedure? (if x car cdr))))
+(test-comp '(lambda (x) #t)
+           '(lambda (x) (fixnum? (if x 2 3))))
+(test-comp '(lambda (x) #f)
+           '(lambda (x) (procedure? (if x 2 3))))
 
 (test-comp '(procedure-arity-includes? integer? 1)
            #t)

--- a/racket/src/racket/src/list.c
+++ b/racket/src/racket/src/list.c
@@ -33,6 +33,7 @@ READ_ONLY Scheme_Object *scheme_pair_p_proc;
 READ_ONLY Scheme_Object *scheme_mpair_p_proc;
 READ_ONLY Scheme_Object *scheme_cons_proc;
 READ_ONLY Scheme_Object *scheme_mcons_proc;
+READ_ONLY Scheme_Object *scheme_list_p_proc;
 READ_ONLY Scheme_Object *scheme_list_proc;
 READ_ONLY Scheme_Object *scheme_list_star_proc;
 READ_ONLY Scheme_Object *scheme_box_proc;
@@ -249,7 +250,9 @@ scheme_init_list (Scheme_Env *env)
                                                             | SCHEME_PRIM_IS_OMITABLE);
   scheme_add_global_constant ("null?", p, env);
 
+  REGISTER_SO(scheme_list_p_proc);
   p = scheme_make_folding_prim(list_p_prim, "list?", 1, 1, 1);
+  scheme_list_p_proc = p;
   SCHEME_PRIM_PROC_FLAGS(p) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_IS_UNARY_INLINED
                                                             | SCHEME_PRIM_IS_OMITABLE);
   scheme_add_global_constant ("list?", p, env);

--- a/racket/src/racket/src/number.c
+++ b/racket/src/racket/src/number.c
@@ -57,6 +57,11 @@
 # define MAX_FIXNUM_SQRT 46339
 #endif
 
+/* read only globals */
+READ_ONLY Scheme_Object *scheme_fixnum_p_proc;
+READ_ONLY Scheme_Object *scheme_flonum_p_proc;
+READ_ONLY Scheme_Object *scheme_extflonum_p_proc;
+
 /* locals */
 static Scheme_Object *number_p (int argc, Scheme_Object *argv[]);
 static Scheme_Object *complex_p (int argc, Scheme_Object *argv[]);
@@ -504,7 +509,9 @@ scheme_init_number (Scheme_Env *env)
                                                             | SCHEME_PRIM_IS_OMITABLE);
   scheme_add_global_constant("exact-positive-integer?", p, env);
 
+  REGISTER_SO(scheme_fixnum_p_proc);
   p = scheme_make_immed_prim(fixnum_p, "fixnum?", 1, 1);
+  scheme_fixnum_p_proc = p;
   SCHEME_PRIM_PROC_FLAGS(p) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_IS_UNARY_INLINED
                                                             | SCHEME_PRIM_IS_OMITABLE);
   scheme_add_global_constant("fixnum?", p, env);
@@ -514,7 +521,9 @@ scheme_init_number (Scheme_Env *env)
                                                             | SCHEME_PRIM_IS_OMITABLE);
   scheme_add_global_constant("inexact-real?", p, env);
 
+  REGISTER_SO(scheme_flonum_p_proc);
   p = scheme_make_folding_prim(flonum_p, "flonum?", 1, 1, 1);
+  scheme_flonum_p_proc = p;
   SCHEME_PRIM_PROC_FLAGS(p) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_IS_UNARY_INLINED
                                                             | SCHEME_PRIM_IS_OMITABLE);
   scheme_add_global_constant("flonum?", p, env);
@@ -1036,7 +1045,9 @@ void scheme_init_extfl_number(Scheme_Env *env)
   Scheme_Object *p;
   int flags;
 
+  REGISTER_SO(scheme_extflonum_p_proc);
   p = scheme_make_folding_prim(extflonum_p, "extflonum?", 1, 1, 1);
+  scheme_extflonum_p_proc = p;
   SCHEME_PRIM_PROC_FLAGS(p) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_IS_UNARY_INLINED
                                                             | SCHEME_PRIM_IS_OMITABLE);
   scheme_add_global_constant("extflonum?", p, env);

--- a/racket/src/racket/src/optimize.c
+++ b/racket/src/racket/src/optimize.c
@@ -2391,8 +2391,10 @@ static Scheme_Object *local_type_to_predicate(int t)
     return scheme_flonum_p_proc;
   case SCHEME_LOCAL_TYPE_FIXNUM:
     return scheme_fixnum_p_proc;
+#ifdef MZ_LONG_DOUBLE
   case SCHEME_LOCAL_TYPE_EXTFLONUM:
     return scheme_extflonum_p_proc;
+#endif
   }
   return NULL;
 }

--- a/racket/src/racket/src/schpriv.h
+++ b/racket/src/racket/src/schpriv.h
@@ -453,6 +453,7 @@ extern Scheme_Object *scheme_unsafe_mcdr_proc;
 extern Scheme_Object *scheme_unsafe_unbox_proc;
 extern Scheme_Object *scheme_cons_proc;
 extern Scheme_Object *scheme_mcons_proc;
+extern Scheme_Object *scheme_list_p_proc;
 extern Scheme_Object *scheme_list_proc;
 extern Scheme_Object *scheme_list_star_proc;
 extern Scheme_Object *scheme_vector_proc;

--- a/racket/src/racket/src/schpriv.h
+++ b/racket/src/racket/src/schpriv.h
@@ -431,6 +431,9 @@ void scheme_done_os_thread();
 /*                                constants                               */
 /*========================================================================*/
 
+extern Scheme_Object *scheme_fixnum_p_proc;
+extern Scheme_Object *scheme_flonum_p_proc;
+extern Scheme_Object *scheme_extflonum_p_proc;
 extern Scheme_Object *scheme_apply_proc;
 extern Scheme_Object *scheme_values_func;
 extern Scheme_Object *scheme_procedure_p_proc;


### PR DESCRIPTION
The optimizer had some reductions of predicates applications, like `(pair? X)`, only when `X` was very simple and the type of `X` was obvious. Use `expr_implies_predicate` and `make_discarding_sequence` to allow the reduction of more complex expressions.

Also, the reduction of `procedure?` and `fixnum?` were special cases in `finish_optimize_application2`. Move the checks to `expr_implies_predicate`  to take advantage of the reductions in more general cases.

The seccond commit is adds a special case to reduce `list?` The predicate reductions use simple disjoint types, so `list?` needs to be handle specially since is a mix of `null?` and only some instances of `pair?`.
