### PR TITLE
Initial version of adding disappeared uses for provide forms.

### DIFF
--- a/racket/collects/racket/private/reqprov.rkt
+++ b/racket/collects/racket/private/reqprov.rkt
@@ -683,15 +683,16 @@
       [(module)
        (syntax-case stx ()
          [(_ out ...)
-          (with-syntax ([(out ...)
-                         (map (lambda (o) (pre-expand-export o null))
-                              (syntax->list #'(out ...)))])
-            (syntax-property
-             (quasisyntax/loc stx 
-               (#%provide #,(syntax-property
-                             #`(expand (provide-trampoline out ...))
-                             'certify-mode 'transparent)))
-             'certify-mode 'transparent))])]
+          (with-provide-disappeared-uses
+            (with-syntax ([(out ...)
+                           (map (lambda (o) (pre-expand-export o null))
+                                (syntax->list #'(out ...)))])
+              (syntax-property
+               (quasisyntax/loc stx
+                 (#%provide #,(syntax-property
+                               #`(expand (provide-trampoline out ...))
+                               'certify-mode 'transparent)))
+               'certify-mode 'transparent)))])]]
       [else
        (raise-syntax-error #f
                            "not at module level"


### PR DESCRIPTION
This is meant to fix one part of pr/13186, that the bindings used for the provide transformer are not caught by check-syntax.

I currently had to reimplement `with-disappeared-uses` because of circularity reasons. Should I split that out to its own file and reuse that machinery, or just re implement a simpler version? I'm thinking the former would be better.