### PR TITLE
Raise error message if _fun is used incorrectly.

### DIFF
--- a/pkgs/racket-test-core/tests/racket/foreign-test.rktl
+++ b/pkgs/racket-test-core/tests/racket/foreign-test.rktl
@@ -151,6 +151,9 @@
 ;; Make sure `_box` at least compiles:
 (test #t ctype? (_fun (_box _int) -> _void))
 
+;; Check error message on bad _fun form
+(syntax-test #'(_fun (bool) :: _bool -> _void) #rx"explicit argument names")
+
 (define-cstruct _ic7i ([i1 _int]
                        [c7 _c7_list]
                        [i2 _int]))

--- a/racket/collects/ffi/unsafe.rkt
+++ b/racket/collects/ffi/unsafe.rkt
@@ -622,7 +622,12 @@
                      [(name : type)        (t-n-e #'type #'name #f)]
                      [(type = expr)        (t-n-e #'type temp   #'expr)]
                      [(name : type = expr) (t-n-e #'type #'name #'expr)]
-                     [type                 (t-n-e #'type temp   #f)])))
+                     [type
+                       (if input-names
+                           (err (string-append
+                                  "Unnamed arguments with no expression are not supported if "
+                                  "explicit argument names are provided"))
+                           (t-n-e #'type temp   #f))])))
                inputs
                (generate-temporaries (map (lambda (x) 'tmp) inputs))))
     ;; when processing the output type, only the post code matters


### PR DESCRIPTION
Closes PR 11323.

I'm not sure if there is a better way to do the check, but the code was fairly hard to follow as it was not standard racket style. Also the error message was really long, so suggestions welcome.