### PR TITLE
Add docs for fsemaphores in the Synchronization section.

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/sync.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sync.scrbl
@@ -3,7 +3,7 @@
 
 @title[#:tag "all-sync" #:style 'toc]{Synchronization}
 
-Racket's synchronization toolbox spans three layers:
+Racket's synchronization toolbox spans four layers:
 
 @itemize[
 
@@ -16,6 +16,9 @@ that compose events); and}
 
 @item{@tech{semaphores} --- a simple and especially cheap primitive
 for synchronization.}
+
+@item{@tech{future semaphores} --- a simple synchronization primitive
+that works well with @tech{futures}.}
 
 ]
 


### PR DESCRIPTION
Closes PR 13380.

It feels somewhat wierd to add this here and not have the docs under synchronization, but I originally filed the bug because I was looking up synchronization primitives and didn't find fsemaphores until much later, so at least wanted a link from this page.