### PR TITLE
Make docs for sgn correct.

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/numbers.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/numbers.scrbl
@@ -1116,7 +1116,7 @@ Converts @racket[x] radians to degrees.
 
 Returns @racket[(* z z)].}
 
-@defproc[(sgn [x real?]) (or/c 1 0 -1 1.0 0.0 -1.0)]{
+@defproc[(sgn [x real?]) (or/c 1 0 -1 1.0 0.0 -0.0 -1.0 +nan.0 1.0f0 0.0f0 -0.0f0 -1.0f0 +nan.f)]{
 
 Returns the sign of @racket[x] as either @math{-1}, @math{0}, or
 @math{1}.


### PR DESCRIPTION
The docs for `sgn` are currently incorrect as they leave out negative zero, nan, and single flonums. This adds all of those to the doc. But I think it might be better to find a way to describe all the values other than by listing them all out. 