### PR TITLE
Check the type of the arguments of more procedures

### DIFF
--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -20,6 +20,7 @@
   (namespace-require 'racket/extflonum)
   (namespace-require 'racket/fixnum)
   (namespace-require 'racket/unsafe/undefined)
+  #;(namespace-require '(rename '#%kernel k:map map))
   (eval '(define-values (prop:thing thing? thing-ref) 
            (make-struct-type-property 'thing)))
   (eval '(struct rock (x) #:property prop:thing 'yes))
@@ -1245,6 +1246,29 @@
            '(lambda (w z) #t)
            #f)
 
+(test-comp '(lambda (x) (car x) #t)
+           '(lambda (x) (car x) (pair? x)))
+(test-comp '(lambda (x) (cdr x) #t)
+           '(lambda (x) (cdr x) (pair? x)))
+(test-comp '(lambda (x) (cadr x) #t)
+           '(lambda (x) (cadr x) (pair? x)))
+(test-comp '(lambda (x) (vector-ref x 0) #t)
+           '(lambda (x) (vector-ref x 0) (vector? x)))
+(test-comp '(lambda (x) (vector-set! x 0 #t) #t)
+           '(lambda (x) (vector-set! x 0 #t) (vector? x)))
+(test-comp '(lambda (f) (procedure-arity-includes? f 5) #t)
+           '(lambda (f) (procedure-arity-includes? f 5) (procedure? f)))
+(test-comp '(lambda (f l) (f l) #t)
+           '(lambda (f l) (f l) (procedure? f)))
+
+; Test the map primitive instead of the redefined version in private/map.rkt 
+(test-comp '(module ? '#%kernel
+              (display #t)
+              (display (lambda (f l) (map f l) #t)))
+           '(module ? '#%kernel
+              (display (primitive? map))
+              (display (lambda (f l) (map f l) (procedure? f)))))
+
 (test-comp '(lambda (w z)
               (let ([x (list* w z)]
                     [y (list* z w)])
@@ -1344,6 +1368,11 @@
                 (unsafe-cdr (begin (random) w))
                 (begin (random) #t)
                 (begin (random) #f))))
+
+(test-comp '(lambda (w) (car w) #t)
+           '(lambda (w) (car w) (pair? w)))
+(test-comp '(lambda (w) (cadr w) #t)
+           '(lambda (w) (cadr w) (pair? w)))
 
 (test-comp '(lambda (w f)
               (list


### PR DESCRIPTION
The optimizer checks the type of the argument of some unary procedures and uses the gathered information to replace them by the unsafe version, reduce predicates and detect type errors. 

This extends the checks to more procedures that have no unsafe version and procedures that have more than one argument.

--

I also thought about checking the primitives compearing the pointers instead of the names, for example change

    check_known(info, app, rator, rand, offset, "car", s__pair_p_proc, s__unsafe_car_proc);

to

    check_known(info, app, rator, rand, offset, s__car_proc, s__pair_p_proc, s__unsafe_car_proc);

But I didn't implement it because I was not sure if this is useful and most of the primitives don't have a global variable.
