### PR TITLE
at-exp: make language-info compose with other languages

### DIFF
--- a/pkgs/at-exp-lib/at-exp/lang/language-info.rkt
+++ b/pkgs/at-exp-lib/at-exp/lang/language-info.rkt
@@ -2,9 +2,19 @@
 
 (provide get-language-info)
 
+(require racket/match)
+
 (define (get-language-info data)
+  (define other-get-info
+    (match data
+      [(vector mod sym data2)
+       ((dynamic-require mod sym) data2)]
+      [_ (lambda (key default) default)]))
   (lambda (key default)
     (case key
       [(configure-runtime)
-       '(#[at-exp/lang/runtime-config configure #f])]
-      [else default])))
+       (define config-vec '#[at-exp/lang/runtime-config configure #f])
+       (define other-config (other-get-info key default))
+       (cond [(list? other-config) (cons config-vec other-config)]
+             [else (list config-vec)])]
+      [else (other-get-info key default)])))

--- a/pkgs/at-exp-lib/at-exp/lang/reader.rkt
+++ b/pkgs/at-exp-lib/at-exp/lang/reader.rkt
@@ -29,9 +29,10 @@
      (lambda (orig-read-syntax)
        (define read-syntax (wrap-reader orig-read-syntax))
        (lambda args
-         (syntax-property (apply read-syntax args)
-                          'module-language
-                          '#(at-exp/lang/language-info get-language-info #f))))
+         (define stx (apply read-syntax args))
+         (define old-prop (syntax-property stx 'module-language))
+         (define new-prop `#(at-exp/lang/language-info get-language-info ,old-prop))
+         (syntax-property stx 'module-language new-prop)))
      (lambda (proc)
        (lambda (key defval)
          (define (fallback) (if proc (proc key defval) defval))


### PR DESCRIPTION
If I use for instance #lang at-exp rackjure, then rackjure #λ literals will still work in the repl, though before this they didn't.  Also if the base language provides other language-info, it will still use that, instead of throwing it away and replacing it completely.  