### PR TITLE
Fix up Issue #919

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/define-struct.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/define-struct.scrbl
@@ -136,6 +136,10 @@ supertype.
 (define p (3d-posn 1 2 3))
 p
 (posn? p)
+(3d-posn-z p)
+(code:comment "a 3d-posn has an x field, but there is no 3d-posn-x-selector:")
+(3d-posn-x p)
+(code:comment "use the supertype's posn-x selector to access the x-field")
 (posn-x p)
 (3d-posn-z p)
 ]


### PR DESCRIPTION
Updated guide to clarify subtype struct inheritance of fields. A subtype inherits supertype's prefixes for fields.