### PR TITLE
Add expansions for and/or to permit higher-order usage

### DIFF
--- a/racket/collects/racket/private/applicable-and-or.rkt
+++ b/racket/collects/racket/private/applicable-and-or.rkt
@@ -1,0 +1,37 @@
+;; -----------------------------------------------------------------------------
+;; applicable expansions for and, or
+
+(module applicable-and-or '#%kernel
+  (#%require (prefix s: "small-scheme.rkt")
+             "define.rkt" "misc.rkt" "for.rkt"
+             (for-syntax "stxcase-scheme.rkt"))
+  
+  (#%provide and or)
+  
+  (define-syntax-rule (define/renamed rename (name . args) body ...)
+    (define name
+      (procedure-rename
+       (λ args body ...)
+       'rename)))
+
+  (define/renamed and (applicable-and . args)
+    (for/fold ([v #t])
+              ([arg (in-list args)])
+      #:break (not v)
+      (s:and v arg)))
+  
+  (define/renamed or (applicable-or . args)
+    (for/fold ([v #f])
+              ([arg (in-list args)])
+      #:break v
+      (s:or v arg)))
+
+  (define-syntax and
+    (syntax-id-rules ()
+      [(_ . args) (s:and . args)]
+      [_ applicable-and]))
+  
+  (define-syntax or
+    (syntax-id-rules ()
+      [(_ . args) (s:or . args)]
+      [_ applicable-or])))

--- a/racket/collects/racket/private/base.rkt
+++ b/racket/collects/racket/private/base.rkt
@@ -12,6 +12,7 @@
              "cert.rkt"
              "submodule.rkt"
              "generic-interfaces.rkt"
+             "applicable-and-or.rkt" ; shadows `and', `or'
              (for-syntax "stxcase-scheme.rkt"))
 
   (#%provide (all-from-except "pre-base.rkt"
@@ -38,6 +39,7 @@
              (all-from "cert.rkt")
              (all-from "submodule.rkt")
              (all-from "generic-interfaces.rkt")
+             (all-from "applicable-and-or.rkt")
              (for-syntax syntax-rules syntax-id-rules ... _)
              (rename -open-input-file open-input-file)
              (rename -open-output-file open-output-file)


### PR DESCRIPTION
This is a work in progress experiment I've implemented based on a discussion I started on the IRC channel. Effectively, this modifies how `and` and `or` expand to permit them to be used as functions.

```racket
(apply and 1 #f 3) ; => #f
```

Obviously, using `and` or `or` as functions disables their short-circuting functionality, but using them as before retains it. Importantly, all usages of these forms in a higher-order manner would have previously been a syntax error, so no working code can possibly be affected by this change.

I *personally* believe this is a worthwhile change, but obviously these are two fairly important forms, so I think a discussion of the pros and cons is needed. I think think the benefits are straightforward:

- Using these operations in a higher-order manner can frequently be useful, and it is not uncommon to have new users unfamiliar with how the macros operate ask questions on IRC after running into a syntax error from a bare use of `and` or `or`.
- Implementing these as alternative expansions of the existing macros makes using them seamless, and follows the principle of least astonishment.
- Any higher-order use of these logical functions wouldn't be able to take advantage of short-circuiting evaluation, anyway (assuming a strict evaluation model), so it is unlikely to cause any surprise in that regard.

The possible downsides I've considered are as follows:

- The "magical" behavior could be even more confusing to new users if they were to accidentally stumble into it. Trying to use `and` as a higher-order function currently just throws a syntax error, which is annoying, but at least the user is prompted to figure out why. On the other hand, if the user expects short-circuit evaluation with this implementation, it will silently "misbehave".
- Introducing this kind of change in `racket/base` could likely have effects on other `#lang`s that make use of the base language's `and` and `or` forms. For example, `r5rs` just uses `and` and `or` from `scheme/base`, so it would need to be modified to use the old behavior.

There are also topics of consideration that aren't necessarily benefits *or* downsides.

- Should these be a part of `racket/base`, `racket/bool`, or some other package? Having them in the standard library would be very nice, but maybe this sort of change isn't suitable for the core language.
- If these did end up in `racket/base`, would there be any easy way to access the legacy behavior? Since this is a superset of the old behavior, it is unlikely that it would really be necessary, but for languages like `r5rs`, it might be useful.

Finally, if moving forward is determined to be a good idea, there are things I'd need to do to get this to an acceptable state.

- [ ] Update reference and guide to adequately explain and document behavior
- [ ] Add tests!
- [ ] Fix the rnrs langs, maybe by changing their behavior in `scheme/base`?