### PR TITLE
More types propagation

### DIFF
--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -1261,12 +1261,41 @@
 (test-comp '(lambda (f l) (f l) #t)
            '(lambda (f l) (f l) (procedure? f)))
 
+(test-comp '(lambda (z) (let ([o #f]) (car z)) #t)
+           '(lambda (z) (let ([o #f]) (car z)) (pair? z)))
+(test-comp '(lambda (z) (let ([o (random)]) (car z)) #t)
+           '(lambda (z) (let ([o (random)]) (car z)) (pair? z)))
+(test-comp '(lambda (z) (let ([o z]) (list (car o) o o)) #t)
+           '(lambda (z) (let ([o z]) (list (car o) o o)) (pair? z)))
+(test-comp '(lambda (z) (let ([o z] [x (random)]) (list (car o) x x)) #t)
+           '(lambda (z) (let ([o z] [x (random)]) (list (car o) x x)) (pair? z)))
+(test-comp '(lambda (z) (let ([f (lambda () (car z))]) (f) #t))
+           '(lambda (z) (let ([f (lambda () (car z))]) (f) (pair? z))))
+(test-comp '(lambda (z) (let ([f (lambda () (car z))]) (f)) #t)
+           '(lambda (z) (let ([f (lambda () (car z))]) (f)) (pair? z)))
+(test-comp '(lambda (z) (let ([f (lambda (i) (car z))]) (f 0) #t))
+           '(lambda (z) (let ([f (lambda (i) (car z))]) (f 0) (pair? z))))
+(test-comp '(lambda (z) (let ([f (lambda (i) (car z))]) (f 0)) #t)
+           '(lambda (z) (let ([f (lambda (i) (car z))]) (f 0)) (pair? z)))
+(test-comp '(lambda (z) (let ([f (lambda (i) (car i))]) (f z) #t))
+           '(lambda (z) (let ([f (lambda (i) (car i))]) (f z) (pair? z))))
+(test-comp '(lambda (z) (let ([f (lambda (i) (car i))]) (f z)) #t)
+           '(lambda (z) (let ([f (lambda (i) (car i))]) (f z)) (pair? z)))
+
 ; Test the map primitive instead of the redefined version in private/map.rkt 
 (test-comp '(module ? '#%kernel
               (display #t)
               (display (lambda (f l) (map f l) #t)))
            '(module ? '#%kernel
               (display (primitive? map))
+              (display (lambda (f l) (map f l) (procedure? f)))))
+
+; Test the map version in private/map.rkt
+(test-comp '(module ? racket/base
+              #;(display #f)
+              (display (lambda (f l) (map f l) #t)))
+           '(module ? racket/base
+              #;(display (primitive? map))
               (display (lambda (f l) (map f l) (procedure? f)))))
 
 (test-comp '(lambda (w z) (vector? (list->vector w)))

--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -1369,16 +1369,54 @@
                 (list l l))))
 
 (test-comp '(lambda (w z)
-              (list (if (pair? w)
-                        (car z)
-                        (car w))
+              (list (if (pair? w) (car w) (car z))
                     (cdr w)))
            '(lambda (w z)
-              (list (if (pair? w)
-                        (car z)
-                        (car w))
+              (list (if (pair? w) (car w) (car z))
                     (unsafe-cdr w)))
            #f)
+
+(test-comp '(lambda (w z)
+              (list (if z (car z) (car w))
+                    (cdr w)))
+           '(lambda (w z)
+              (list (if z (car z) (car w))
+                    (unsafe-cdr w)))
+           #f)
+
+(test-comp '(lambda (w z)
+              (list (if (pair? w) (car z) (car w))
+                    (cdr w)))
+           '(lambda (w z)
+              (list (if (pair? w) (car z) (car w))
+                    (unsafe-cdr w))))
+
+(test-comp '(lambda (w z)
+              (list (if z (car w) (cdr w))
+                    (cdr w)))
+           '(lambda (w z)
+              (list (if z (car w) (cdr w))
+                    (unsafe-cdr w))))
+
+(test-comp '(lambda (w z x)
+              (list (car x) (if z (car w) (cdr w)) (car x)))
+           '(lambda (w z x)
+              (list (car x) (if z (car w) (cdr w)) (unsafe-car x))))
+
+(test-comp '(lambda (w z x)
+              (list (car x) (if z (car w) 2) (car x)))
+           '(lambda (w z x)
+              (list (car x) (if z (car w) 2) (unsafe-car x))))
+
+(test-comp '(lambda (w z x)
+              (list (car x) (if z 1 (cdr w)) (car x)))
+           '(lambda (w z x)
+              (list (car x) (if z 1 (cdr w)) (unsafe-car x))))
+
+(test-comp '(lambda (w z x)
+              (list (car x) (if z 1 2) (car x)))
+           '(lambda (w z x)
+              (list (car x) (if z 1 2) (unsafe-car x))))
 
 (test-comp '(lambda (w)
               (list
@@ -4603,7 +4641,7 @@
           (read (open-input-bytes (get-output-bytes o))))))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Check that an unsufe opertion's argument is
+;; Check that an unsafe opertion's argument is
 ;; not "optimized" away if it's a use of
 ;; a variable before definition:
 


### PR DESCRIPTION
The fist commit enables the propagation of types from the body of a `let` form to the surrounding code, for example in

    (lambda (z) (let ([o (random)]) (car z)) (pair? z))
    (lambda (z) (let ([o z]) (car o)) (pair? z))

reduce `(pair? z) ==> #t`.

The second commit extends this propagation to inlined functions.

I'm still worried because I'm using a very simple method to shift the coordinates in both cases.

The third commit calculates the intersection of the types of the two `if` branches. I tried to minimize the creation of new `trees` to hold the type information. I assume that most of the time one of the branches doesn't add new type information.

The last commit just add a test for an inference with `map`, that is possible using all the modifications of the previous commits.
