### PR TITLE
Fix the first order check on async-channel/c

### DIFF
--- a/pkgs/racket-test/tests/racket/contract/async-channel.rkt
+++ b/pkgs/racket-test/tests/racket/contract/async-channel.rkt
@@ -23,4 +23,11 @@
    '(let ([ac (contract (async-channel/c (cons/c (-> boolean? boolean?) '()))
                (make-async-channel) 'pos 'neg)])
       (async-channel-put ac (list values))
-      ((car (async-channel-get ac)) 3))))
+      ((car (async-channel-get ac)) 3)))
+
+  (test/spec-passed
+   'async-channel/c-with-higher-order
+   '(let ([ac (contract (or/c (async-channel/c integer?) (integer? . -> . integer?))
+               (make-async-channel) 'pos 'neg)])
+      (async-channel-put ac 1)
+      (async-channel-get ac))))

--- a/racket/collects/racket/async-channel.rkt
+++ b/racket/collects/racket/async-channel.rkt
@@ -209,9 +209,7 @@
                            val '(expected "an async channel" given: "~e") val))))
 
 (define ((async-channel/c-first-order ctc) val)
-  (define elem-ctc (base-async-channel/c-content ctc))
-  (and (async-channel? val)
-       (contract-first-order-passes? elem-ctc val)))
+  (async-channel? val))
 
 (define (async-channel/c-stronger? a b)
   (contract-stronger? (base-async-channel/c-content a) (base-async-channel/c-content b)))
@@ -251,7 +249,7 @@
   #:property prop:chaperone-contract
   (build-chaperone-contract-property
    #:name async-channel/c-name
-   #:first-order async-channel?
+   #:first-order async-channel/c-first-order
    #:stronger async-channel/c-stronger?
    #:val-first-projection (ho-val-first-projection chaperone-async-channel)
    #:projection (ho-projection chaperone-async-channel)))
@@ -261,7 +259,7 @@
   #:property prop:contract
   (build-contract-property
    #:name async-channel/c-name
-   #:first-order async-channel?
+   #:first-order async-channel/c-first-order
    #:stronger async-channel/c-stronger?
    #:val-first-projection (ho-val-first-projection impersonate-async-channel)
    #:projection (ho-projection impersonate-async-channel)))


### PR DESCRIPTION
This is my fault. When I wrote this initially I had a shaky understanding of how the contract system worked internally, and the first order check was wrong. Without this fix, simply calling `contract-first-order` on an async channel contract would throw an exception because the first order check isn't properly curried.

Anyway, it's fixed now, and I've added a test covering it.