### PR TITLE
Add stream* to complement stream

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/sequences.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sequences.scrbl
@@ -828,6 +828,12 @@ stream, but plain lists can be used as streams, and functions such as
   @racket[empty-stream].
 }
 
+@defform[(stream* expr ...)]{
+  A shorthand for nested @racket[stream-cons]es, but the final @racket[expr]
+  must be a stream, and it is used as the rest of the stream instead of
+  @racket[empty-stream]. Similar to @racket[list*] but for streams.
+}
+
 @defproc[(in-stream [s stream?]) sequence?]{
   Returns a sequence that is equivalent to @racket[s].
   @speed[in-stream "streams"]

--- a/pkgs/racket-test-core/tests/racket/stream.rktl
+++ b/pkgs/racket-test-core/tests/racket/stream.rktl
@@ -35,6 +35,8 @@
 (test 4 stream-ref one-to-four 3)
 (test 2 'stream (stream-length (stream 1 (/ 0))))
 (test 'a 'stream (stream-first (stream 'a (/ 0))))
+(test 2 'stream* (stream-length (stream* 1 (stream (/ 0)))))
+(test 'a 'stream* (stream-first (stream* 'a (stream (/ 0)))))
 
 ;; make sure stream operations work on lists
 (test #t stream-empty? '())

--- a/racket/collects/racket/stream.rkt
+++ b/racket/collects/racket/stream.rkt
@@ -27,6 +27,7 @@
          in-stream
 
          stream
+         stream*
          stream->list
          stream-length
          stream-ref
@@ -57,6 +58,13 @@
      empty-stream)
     ((_ hd tl ...)
      (stream-cons hd (stream tl ...)))))
+
+(define-syntax stream*
+  (syntax-rules ()
+    [(_ hd tl)
+     (stream-cons hd tl)]
+    [(_ hd tl ...)
+     (stream-cons hd (stream* tl ...))]))
 
 (define (stream->list s)
   (for/list ([v (in-stream s)]) v))


### PR DESCRIPTION
Adds `stream*` to `racket/stream`, which functions similarly to `list*`, but produces a stream.