### PR TITLE
Improvements to unit/c contracts to support units in typed racket

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/units.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/units.scrbl
@@ -727,10 +727,10 @@ the unit value must declare initialization dependencies that are a subset of
 those specified in the unit contract. Any identifier which is not listed
 for a given signature is left alone. Variables used in a given
 @racket[contract] expression first refer to other variables in the same
-signature, and then to the context of the @racket[unit/c] expression.}
+signature, and then to the context of the @racket[unit/c] expression.
 If a body contract is specified then the result of invoking the unit value
 is wrapped with the given contract, if no body contract is supplied then
-no wrapping occurs when the unit value is invoked.
+no wrapping occurs when the unit value is invoked.}
 
 @defform/subs[#:literals (import export values)
               (define-unit/contract unit-id

--- a/pkgs/racket-doc/scribblings/reference/units.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/units.scrbl
@@ -700,10 +700,21 @@ Expands to a @racket[provide] of all identifiers implied by the
 
 @section[#:tag "unitcontracts"]{Unit Contracts}
 
-@defform/subs[#:literals (import export)
-              (unit/c (import sig-block ...) (export sig-block ...))
+@defform/subs[#:literals (import export values init-depend)
+              (unit/c
+	        (import sig-block ...)
+	        (export sig-block ...)
+		init-depends-decl
+		optional-body-ctc)
               ([sig-block (tagged-sig-id [id contract] ...)
-                          tagged-sig-id])]{
+                          tagged-sig-id]
+	       [init-depends-decl
+	         code:blank
+		 (init-depend tagged-sig-id ...)]
+	       [optional-body-ctc
+	         code:blank
+		 contract
+		 (values contract ...)])]{
 
 A @deftech{unit contract} wraps a unit and checks both its imported and
 exported identifiers to ensure that they match the appropriate contracts.
@@ -711,21 +722,30 @@ This allows the programmer to add contract checks to a single unit value
 without adding contracts to the imported and exported signatures.
 
 The unit value must import a subset of the import signatures and export a
-superset of the export signatures listed in the unit contract.  Any
-identifier which is not listed for a given signature is left alone.
-Variables used in a given @racket[contract] expression first refer to other
-variables in the same signature, and then to the context of the 
-@racket[unit/c] expression.}
+superset of the export signatures listed in the unit contract. Additionally,
+the unit value must declare initialization dependencies that are a subset of
+those specified in the unit contract. Any identifier which is not listed
+for a given signature is left alone. Variables used in a given
+@racket[contract] expression first refer to other variables in the same
+signature, and then to the context of the @racket[unit/c] expression.}
+If a body contract is specified then the result of invoking the unit value
+is wrapped with the given contract, if no body contract is supplied then
+no wrapping occurs when the unit value is invoked.
 
-@defform/subs[#:literals (import export)
+@defform/subs[#:literals (import export values)
               (define-unit/contract unit-id
                 (import sig-spec-block ...)
                 (export sig-spec-block ...)
                 init-depends-decl
+		optional-body-ctc
                 unit-body-expr-or-defn
                 ...)
               ([sig-spec-block (tagged-sig-spec [id contract] ...)
-                               tagged-sig-spec])]{
+                               tagged-sig-spec]
+	       [optional-body-ctc
+	         code:blank
+		 (code:line #:invoke/contract contract)
+		 (code:line #:invoke/contract (values contract ...))])]{
 The @racket[define-unit/contract] form defines a unit compatible with
 link inference whose imports and exports are contracted with a unit
 contract.  The unit name is used for the positive blame of the contract.}

--- a/pkgs/racket-test/tests/units/test-unit-contracts.rkt
+++ b/pkgs/racket-test/tests/units/test-unit-contracts.rkt
@@ -893,4 +893,104 @@
   (define-values/invoke-unit c@ (import) (export s^))
   (new-make-t))
 
+
+(let ()
+  (define-signature s^ ((contracted [n number?])))
+  (define-unit s0@
+    (import)
+    (export s^)
+    (define n 0))
+
+  (define-unit s1@
+    (import)
+    (export s^)
+    (define n 1))
+
+  (define-unit/contract a0@
+    (import)
+    (export)
+    #:invoke/contract (-> integer? integer?)
+    (lambda (n) (add1 n)))
+
+  (define-unit/contract a1@
+    (import)
+    (export)
+    (init-depend)
+    #:invoke/contract (-> integer? integer?)
+    (lambda (n) "bad"))
+
+  ((invoke-unit a0@) 1)
+  (test-contract-error "(unit a1@)" "a1@" "not an integer" ((invoke-unit a1@) 1))
+
+  (define-unit t@
+    (import s^)
+    (export)
+    (if (zero? n) "zero" n))
+
+  (define c@/c (unit/c (import) (export) number?))
+  (define/contract c0@ c@/c
+    (compound-unit (import) (export) (link [((S : s^)) s0@] [() t@ S])))
+  (define/contract c1@ c@/c
+    (compound-unit (import) (export) (link [((S : s^)) s1@] [() t@ S])))
+  (test-contract-error "(definition c0@)" "c0@" "not a number" (invoke-unit c0@))
+  (invoke-unit c1@))
+
+;; tests for init-depends in unit contracts
+(let ()
+  (define-signature a^ ())
+  (define-signature b^ ())
+  (define-signature c^ ())
+
+  (define/contract u@
+    (unit/c (import a^ b^) (export) (init-depend a^ b^))
+    (unit (import a^ b^) (export) (init-depend a^ b^)))
+
+  (define/contract v@
+    (unit/c (import a^ b^) (export) (init-depend a^ b^))
+    (unit (import a^) (export) (init-depend a^)))
+
+  (test-contract-error
+   "(definition w@)" "w@" "missing init-depend"
+   (let ()
+     (define/contract w@
+       (unit/c (import a^) (export))
+       (unit (import a^) (export) (init-depend a^)))
+     w@))
+
+  ;; make sure that extended dependencies are checked correctly
+  (define-signature a-sub^ extends a^ ())
+  (define/contract x@
+    (unit/c (import a-sub^) (export) (init-depend a-sub^))
+    (unit (import a^) (export) (init-depend a^)))
+
+  ;; make sure tags are checked correctly for init-depends
+  (test-contract-error
+   "(definition y@)" "y@" "untagged init-depend"
+   (let ()
+     (define/contract y@
+       (unit/c (import (tag A a^) a^) (export) (init-depend a^))
+       (unit (import (tag A a^) a^) (export) (init-depend (tag A a^))))
+     y@))
+
+  (test-syntax-error
+   "unit/c: initialization dependency on unknown import in: a-sub^"
+   (unit/c (import a^) (export) (init-depend a-sub^)))
+  (test-syntax-error
+   "unit/c: unknown import"
+   (unit/c (import) (export) (init-depend a^)))
+
+  (test-syntax-error
+   "unit/c: unknown signature"
+   (unit/c (import x^) (export) (init-depend)))
+
+  (test-syntax-error
+   "unit/c: unknown signature"
+   (unit/c (import) (export) (init-depend x^)))
+
+  (test-syntax-error
+   "unit/c: unknown signature"
+   (unit/c (import) (export x^) (init-depend)))
+
+  (void))
+
 (displayln "tests passed")

--- a/racket/collects/racket/private/unit-contract-syntax.rkt
+++ b/racket/collects/racket/private/unit-contract-syntax.rkt
@@ -8,17 +8,10 @@
 (provide import-clause/contract export-clause/contract body-clause/contract dep-clause
          import-clause/c export-clause/c body-clause/c)
 
-;; This pattern is extremely permissive, but it allows for
-;; the unit machinery to give better error mesages rather
-;; than resulting in parse failures
-(define-syntax-class sig-id
-  #:attributes ()
-  (pattern x))
-
 (define-syntax-class sig-spec #:literals (prefix rename only except)
   #:attributes ((name 0))
   #:transparent
-  (pattern name:sig-id)
+  (pattern name)
   (pattern (prefix i:identifier s:sig-spec)
            #:with name #'s.name)
   (pattern (rename s:sig-spec [int:identifier ext:identifier] ...)
@@ -38,8 +31,8 @@
 (define-syntax-class tagged-sig-id #:literals (tag)
   #:attributes ()
   #:transparent
-  (pattern s:sig-id)
-  (pattern (tag i:identifier s:sig-id)))
+  (pattern s)
+  (pattern (tag i:identifier s)))
 
 (define-syntax-class unit/c-clause
   #:auto-nested-attributes

--- a/racket/collects/racket/private/unit-contract.rkt
+++ b/racket/collects/racket/private/unit-contract.rkt
@@ -68,10 +68,18 @@
 
 (define-for-syntax contract-imports (contract-imports/exports #t))
 (define-for-syntax contract-exports (contract-imports/exports #f))
+;; This is copied from the unit implementation, but can't be required
+;; from there since unit.rkt also requires this file
+(define-for-syntax (tagged-sigid->tagged-siginfo x)
+  (cons (car x)
+        (signature-siginfo (lookup-signature (cdr x)))))
 
 (define-for-syntax (unit/c/core name stx)
   (syntax-parse stx
-    [(:import-clause/c :export-clause/c)
+    [(:import-clause/c
+      :export-clause/c
+      (~optional d:dep-clause #:defaults ([(d.s 1) null]))
+      b:body-clause/c)
      (begin
        (define-values (isig tagged-import-sigs import-tagged-infos 
                             import-tagged-sigids import-sigs)
@@ -80,7 +88,14 @@
        (define-values (esig tagged-export-sigs export-tagged-infos 
                             export-tagged-sigids export-sigs)
          (process-unit-export #'(e.s ...)))
-       
+
+       (define deps (syntax->list #'(d.s ...)))
+       (define dep-tagged-siginfos
+         (map tagged-sigid->tagged-siginfo
+              (map check-tagged-id deps)))
+
+       (define body-contract (attribute b.apply-invoke-ctcs))
+
        (define contract-table
          (make-bound-identifier-mapping))
        
@@ -102,11 +117,8 @@
                [c (in-list (syntax->list cs))])
               (bound-identifier-mapping-put! contract-table x c)))
        
-       (check-duplicate-sigs import-tagged-infos isig null null)
-       
+       (check-duplicate-sigs import-tagged-infos isig dep-tagged-siginfos deps)
        (check-duplicate-subs export-tagged-infos esig)
-       
-       (check-unit-ie-sigs import-sigs export-sigs)
        
        (for-each process-sig
                  isig
@@ -119,7 +131,13 @@
                  (syntax->list #'((e.x ...) ...))
                  (syntax->list #'((e.c ...) ...)))
        
-       (with-syntax ([(isig ...) isig]
+       (with-syntax ([((dept . depr) ...)
+                      (map
+                       (lambda (tinfo)
+                         (cons (car tinfo)
+                               (syntax-local-introduce (car (siginfo-rtime-ids (cdr tinfo))))))
+                       dep-tagged-siginfos)]
+                     [(isig ...) isig]
                      [(esig ...) esig]
                      [((import-key ...) ...)
                       (map tagged-info->keys import-tagged-infos)]
@@ -145,7 +163,10 @@
                           (list (cons 'esig
                                       (map list (list 'e.x ...)
                                            (build-compound-type-name 'e.c ...)))
-                                ...)))
+                                ...))
+                    (cons 'init-depend
+                          (list 'd.s ...))
+                    #,@(attribute b.name))
               #:projection
               (λ (blame)
                 (λ (unit-tmp)
@@ -157,6 +178,7 @@
                    (vector-immutable 
                     (cons 'export-name 
                           (vector-immutable export-key ...)) ...)
+                   (list (cons 'dept depr) ...)
                    blame)
                   (make-unit
                    '#,name
@@ -164,16 +186,18 @@
                                            (vector-immutable import-key ...)) ...)
                    (vector-immutable (cons 'export-name 
                                            (vector-immutable export-key ...)) ...)
-                   (unit-deps unit-tmp)
+                   (list (cons 'dept depr) ...)
                    (λ ()
                      (let-values ([(unit-fn export-table) ((unit-go unit-tmp))])
                        (values (lambda (import-table)
-                                 (unit-fn #,(contract-imports
-                                             #'import-table
-                                             import-tagged-infos
-                                             import-sigs
-                                             contract-table
-                                             #'blame)))
+                                 #,(body-contract
+                                    #`(unit-fn #,(contract-imports
+                                                  #'import-table
+                                                  import-tagged-infos
+                                                  import-sigs
+                                                  contract-table
+                                                  #'blame))
+                                    #'blame))
                                #,(contract-exports 
                                   #'export-table
                                   export-tagged-infos
@@ -190,6 +214,7 @@
                  (vector-immutable 
                   (cons 'export-name 
                         (vector-immutable export-key ...)) ...)
+                 (list (cons 'dept depr) ...)
                  #f)))))))]))
 
 (define-syntax/err-param (unit/c stx)
@@ -198,7 +223,7 @@
      (let ([name (syntax-local-infer-name stx)])
        (unit/c/core name #'sstx))]))
 
-(define (unit/c-first-order-check val expected-imports expected-exports blame)
+(define (unit/c-first-order-check val expected-imports expected-exports expected-deps blame)
   (let/ec return
     (define (failed str . args)
       (if blame
@@ -224,12 +249,53 @@
                  [r (hash-ref t v0 #f)])
             (when (not r)
               (let ([sub-name (car (vector-ref super-sig i))])
-                (if import?
-                    (failed "contract does not list import ~a" sub-name)
-                    (failed "unit must export signature ~a" sub-name)))))
+                (define tag-part (vector-ref (cdr (vector-ref super-sig i)) 0))
+                (define tag (and (pair? tag-part) (car tag-part)))
+                (failed
+                 (string-append
+                  (if import?
+                      (format "contract does not list import ~a" sub-name)
+                      (format "unit must export signature ~a" sub-name))
+                  (if tag
+                      (format " with tag ~a" tag)
+                      ""))))))
           (loop (sub1 i)))))
+    (define (check-dependencies expected given imports)
+      (define (lookup dep lst)
+        (member dep lst (lambda (p1 p2)
+                          (and (eq? (car p1) (car p2))
+                               (eq? (cdr p1) (cdr p2))))))
+      (define (normalize-deps deps)
+        (map (lambda (dep) (if (car dep) dep (cdr dep))) deps))
+      (define t (for*/hash ([i (in-vector imports)]
+                            [v (in-value (cdr i))]
+                            [im (in-value (vector-ref v 0))]
+                            #:when (member im (normalize-deps expected))
+                            [vj (in-vector v)])
+                  (values vj #t)))
+      ;; use the imports to get the name and tag of dependency
+      (define (get-name dep-tag)
+        (define tag-table
+          (for/hash ([e (in-vector imports)])
+            (define name (car e))
+            (define v (vector-ref (cdr e) 0))
+            (define tag (if (pair? v) (cdr v) v))
+            (values tag name)))
+        (hash-ref tag-table dep-tag #f))
+     (for ([dep (in-list (normalize-deps given))])
+       (unless (hash-ref t dep #f)
+         (define tag (and (pair? dep) (car dep)))
+         (define sig-tag (or (and (pair? dep) (cdr dep)) dep))
+         (failed
+               (string-append
+                (format "contract does not list initialization dependency ~a"
+                        (get-name sig-tag))
+                (if tag
+                    (format " with tag ~a" tag)
+                    ""))))))
     (unless (unit? val)
       (failed "not a unit"))
     (check-sig-subset expected-imports (unit-import-sigs val) #t)
     (check-sig-subset (unit-export-sigs val) expected-exports #f)
+    (check-dependencies expected-deps (unit-deps val) expected-imports)
     #t))

--- a/racket/collects/racket/unit.rkt
+++ b/racket/collects/racket/unit.rkt
@@ -1899,14 +1899,17 @@
                            (build-unit-from-context sig))
                      "missing unit name and signature"))
 
+(define-for-syntax no-invoke-contract (gensym))
 (define-for-syntax (build-unit/contract stx)
   (syntax-parse stx
-                [(:import-clause/contract :export-clause/contract dep:dep-clause . body)
+                [(:import-clause/contract :export-clause/contract dep:dep-clause :body-clause/contract . bexps)
+                 (define splicing-body-contract
+                   (if (eq? (syntax-e #'b) no-invoke-contract) #'() #'(b)))
                  (let-values ([(exp isigs esigs deps) 
                                (build-unit
                                 (check-unit-syntax
                                  (syntax/loc stx
-                                   ((import i.s ...) (export e.s ...) dep . body))))])
+                                   ((import i.s ...) (export e.s ...) dep . bexps))))])
                    (with-syntax ([name (syntax-local-infer-name (error-syntax))]
                                  [(import-tagged-sig-id ...)
                                   (map (λ (i s)
@@ -1922,17 +1925,27 @@
                                    [unit-contract
                                     (unit/c/core
                                      #'name
-                                     (syntax/loc stx
+                                     (quasisyntax/loc stx
                                        ((import (import-tagged-sig-id [i.x i.c] ...) ...)
-                                        (export (export-tagged-sig-id [e.x e.c] ...) ...))))])
+                                        (export (export-tagged-sig-id [e.x e.c] ...) ...)
+                                        dep
+                                        #,@splicing-body-contract)))])
                        (values 
                         (syntax/loc stx
                           (contract unit-contract new-unit '(unit name) (current-contract-region) (quote name) (quote-srcloc name)))
                         isigs esigs deps))))]
-                [(ic:import-clause/contract ec:export-clause/contract . body)
-                 (build-unit/contract 
-                  (syntax/loc stx
-                    (ic ec (init-depend) . body)))]))
+                [(ic:import-clause/contract ec:export-clause/contract dep:dep-clause . bexps)
+                 (build-unit/contract
+                  (quasisyntax/loc stx
+                    (ic ec dep #:invoke/contract #,no-invoke-contract . bexps)))]
+                [(ic:import-clause/contract ec:export-clause/contract bc:body-clause/contract . bexps)
+                 (build-unit/contract
+                  (quasisyntax/loc stx
+                    (ic ec (init-depend) #,@(syntax->list #'bc) . bexps)))]
+                [(ic:import-clause/contract ec:export-clause/contract . bexps)
+                 (build-unit/contract
+                  (quasisyntax/loc stx
+                    (ic ec (init-depend) #:invoke/contract #,no-invoke-contract . bexps)))]))
 
 (define-syntax/err-param (define-unit/contract stx)
   (build-define-unit/contracted stx (λ (stx)

--- a/racket/collects/racket/unit.rkt
+++ b/racket/collects/racket/unit.rkt
@@ -1899,6 +1899,7 @@
                            (build-unit-from-context sig))
                      "missing unit name and signature"))
 
+;; A marker used when the result of invoking a unit should not be contracted
 (define-for-syntax no-invoke-contract (gensym))
 (define-for-syntax (build-unit/contract stx)
   (syntax-parse stx


### PR DESCRIPTION
This pull request extends unit contracts to support Unit types in racket/typed-racket#142

Changes:

 - Allow unit contracts to import and export the same signature.
 - Add "invoke" contracts that will wrap the result of invoking a unit contract,
   no wrapping occurs when a body contract is not specified
 - Improve error messages
 - Support for init-depend clauses in unit contracts.

Handling init-depend clauses in unit contracts is a rather large and somewhat
non-backwards-compatible change to unit contracts. Unit contracts must now
specify at least as many initialization dependencies as the unit value being
contracted, but may include more. These new dependencies are now actually
specified in the unit wrapper so that they will be checked by compound-unit
expressions.

Additionally, this commit adds more information to the first-order-check
error messages. If a unit imports tagged signatures, previously the errror
message did not specify which tag was missing from the unit contract. Now
the tag is printed along with the signature name.