### PR TITLE
Fix contract error in in-vector documentation example

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/sequences.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sequences.scrbl
@@ -244,7 +244,7 @@ each element in the sequence.
 
   @interaction[#:eval sequence-evaluator
     (define (histogram vector-of-words)
-      (define a-hash (hash))
+      (define a-hash (make-hash))
       (for ([word (in-vector vector-of-words)])
         (hash-set! a-hash word (add1 (hash-ref a-hash word 0))))
       a-hash)


### PR DESCRIPTION
The example given for `in-vector` uses an immutable hash where it should use a mutable one, which raises a contract error that should definitely not be a part of the example. This changes it to use a mutable hash.