### PR TITLE
Add pointer accessor for cstruct fields.

### DIFF
--- a/pkgs/racket-doc/scribblings/foreign/types.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/types.scrbl
@@ -1122,6 +1122,9 @@ The resulting bindings are as follows:
  @item{@racketidfont{set-}@racketvarfont{id}@racketidfont{-}@racket[field-id]@racketidfont{!}
   : a mutator function for each @racket[field-id].}
 
+ @item{@racketvarfont{id}@racketidfont{-}@racket[field-id]@racketidfont{-pointer} : an accessor
+  function for each @racket[field-id] that returns a pointer to the field.}
+
  @item{@racketvarfont{id}: structure-type information compatible with
   @racket[struct-out] or @racket[match] (but not @racket[struct] or 
   @racket[define-struct]);
@@ -1320,7 +1323,8 @@ expects arguments for both the super fields and the new ones:
 ]
 
 @history[#:changed "6.0.0.6" @elem{Added @racket[#:malloc-mode].}
-         #:changed "6.1.1.8" @elem{Added @racket[#:offset] for fields.}]}
+         #:changed "6.1.1.8" @elem{Added @racket[#:offset] for fields.}
+         #:changed "6.2.0.4" @elem{Added pointer accessor for fields.}]}
 
 @; ------------------------------------------------------------
 

--- a/pkgs/racket-test-core/tests/racket/foreign-test.rktl
+++ b/pkgs/racket-test-core/tests/racket/foreign-test.rktl
@@ -474,6 +474,15 @@
   (test 1 ptr-ref v _int16 0)
   (test 3 ptr-ref v _int16 3))
 
+;; Test cstruct pointer access
+(let ()
+  (define-cstruct _stuff ([a _int16]
+                          [b _int32]))
+  (define v (make-stuff 1 0))
+  (test 1 ptr-ref (stuff-a-pointer v) _int16)
+  (ptr-set! (stuff-b-pointer v) _int32 3)
+  (test 3 ptr-ref (stuff-b-pointer v) _int32))
+
 ;; Test intptr:
 (let ([v (malloc _pointer)])
   (ptr-set! v _pointer (ptr-add #f 107))

--- a/racket/collects/ffi/unsafe.rkt
+++ b/racket/collects/ffi/unsafe.rkt
@@ -1463,6 +1463,7 @@
          [(stype ...)          (ids (lambda (s) `(,name"-",s"-type")))]
          [(TYPE-SLOT ...)      (ids (lambda (s) `(,name"-",s)))]
          [(set-TYPE-SLOT! ...) (ids (lambda (s) `("set-",name"-",s"!")))]
+         [(TYPE-SLOT-pointer ...)      (ids (lambda (s) `(,name"-",s"-pointer")))]
          [(offset ...) (generate-temporaries
                                (ids (lambda (s) `(,s"-offset"))))]
          [alignment            alignment-stx]
@@ -1530,7 +1531,7 @@
                        (reverse (list (quote-syntax set-TYPE-SLOT!) ...))
                        #t))))
             (define-values (_TYPE _TYPE-pointer _TYPE-pointer/null TYPE? TYPE-tag
-                                  make-TYPE TYPE-SLOT ... set-TYPE-SLOT! ...
+                                  make-TYPE TYPE-SLOT ... set-TYPE-SLOT! ... TYPE-SLOT-pointer ...
                                   list->TYPE list*->TYPE TYPE->list TYPE->list*
                                   maybe-struct:TYPE ...)
               (let-values ([(super-pointer super-tags super-types super-offsets
@@ -1574,6 +1575,11 @@
                   (unless (TYPE? x)
                     (raise-argument-error 'set-TYPE-SLOT! struct-string 0 x slot))
                   (ptr-set! x stype 'abs offset slot))
+                ...
+                (define (TYPE-SLOT-pointer x)
+                  (unless (TYPE? x)
+                    (raise-argument-error 'TYPE-SLOT-pointer struct-string x))
+                  (ptr-add x offset))
                 ...
                 (define make-TYPE
                   (if (and has-super? super-types super-offsets)
@@ -1638,7 +1644,7 @@
                  _TYPE all-tags all-types all-offsets TYPE->list* list*->TYPE
                  struct:cpointer:TYPE wrap-TYPE-type)
                 (values _TYPE* _TYPE-pointer _TYPE-pointer/null TYPE? TYPE-tag
-                        make-TYPE TYPE-SLOT ... set-TYPE-SLOT! ...
+                        make-TYPE TYPE-SLOT ... set-TYPE-SLOT! ... TYPE-SLOT-pointer ...
                         list->TYPE list*->TYPE TYPE->list TYPE->list*
                         maybe-struct:TYPE ...)))))))
   (define (err what . xs)


### PR DESCRIPTION
The use case for this feature is allocating a struct that will hold many different values. Then passing the pointers to those values on to the foreign interface. Having them all in the same struct means that lifetime management is easier.