### PR TITLE
Reoptimize propagated constants

### DIFF
--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -1689,6 +1689,8 @@
 
 (test-comp '(lambda (x) (not (if x #f 2)))
            '(lambda (x) (not (if x #f #t))))
+(test-comp '(lambda (x) (let ([z 2]) (not (if x #f z))))
+           '(lambda (x) (let ([z 2]) (not (if x #f #t)))))
 
 (test-comp '(lambda (x) (if x x #f))
            '(lambda (x) x))

--- a/racket/src/racket/src/optimize.c
+++ b/racket/src/racket/src/optimize.c
@@ -7372,7 +7372,8 @@ Scheme_Object *scheme_optimize_expr(Scheme_Object *expr, Optimize_Info *info, in
           if (val)
             return val;
         } else {
-          if (SAME_TYPE(SCHEME_TYPE(val), scheme_compiled_toplevel_type)) {
+          if (SAME_TYPE(SCHEME_TYPE(val), scheme_compiled_toplevel_type)
+              || (SCHEME_TYPE(val) > _scheme_compiled_values_types_)) {
             info->size -= 1;
             return scheme_optimize_expr(val, info, context);
           }


### PR DESCRIPTION
Reduces them to #t or #f when they are copied to a Boolean context.

For example in

    (lambda (x) (let ([z 2]) (not (if x #f z)))

reduce the bound `z` to `#t`.
