### PR TITLE
disabled HAVE_POLL_SYSCALL in solaris

### DIFF
--- a/racket/src/configure
+++ b/racket/src/configure
@@ -4537,7 +4537,7 @@ case "$host_os" in
     LIBS="$LIBS -lsocket -lnsl -lintl"
     need_gcc_static_libgcc="yes"
     check_gcc_dash_e="yes"
-    try_poll_syscall="yes"
+    try_poll_syscall="no"
     use_flag_pthread="no"
     use_flag_posix_pthread="yes"
     ;;


### PR DESCRIPTION
poll(2) is the CPU eater, and it affects all TCP applications including the plt-web-server.

I am not sure if this is a bug of poll(2), or just a poor implementation in RVM.
It's reasonable to suggest that it could be improved with another Event Completion Framework in the future.