### PR TITLE
A bugfix and more types features

### DIFF
--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -1763,7 +1763,8 @@
                     `(lambda (x) (if (,pred? x) x 0))))])
   (test-pred-implies-val 'null? 'null)
   (test-pred-implies-val 'void? '(void))
-  (test-pred-implies-val 'eof-object? 'eof))
+  (test-pred-implies-val 'eof-object? 'eof)
+  (test-pred-implies-val 'not '#f))
 (test-comp '(lambda (x) (if (null? x) 1 0) null)
            '(lambda (x) (if (null? x) 1 0) x)
            #f)
@@ -1773,6 +1774,8 @@
            '(lambda (x) (if (eq? x (list 0)) (pair? x) 0)))
 (test-comp '(lambda (x y) (car y) (if (eq? x y) #t 0))
            '(lambda (x y) (car y) (if (eq? x y) (pair? x) 0)))
+(test-comp '(lambda (x) (if x 1 (list #f)))
+           '(lambda (x) (if x 1 (list x))))
 
 
 (test-comp '(lambda (x) (let ([r (something)])

--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -1752,6 +1752,17 @@
                           (if r #t (something-else))))
            '(lambda (x) (if (something) #t (something-else))))
 
+(let ([test-pred-implies-val
+       (lambda (pred? val)
+         (test-comp `(lambda (x) (if (,pred? x) ,val 0))
+                    `(lambda (x) (if (,pred? x) x 0))))])
+  (test-pred-implies-val 'null? 'null)
+  (test-pred-implies-val 'void? '(void))
+  (test-pred-implies-val 'eof-object? 'eof))
+(test-comp '(lambda (x) (if (null? x) 1 0) null)
+           '(lambda (x) (if (null? x) 1 0) x)
+           #f)
+
 (test-comp '(lambda (x) (let ([r (something)])
                           (r)))
            '(lambda (x) ((something))))

--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -1485,6 +1485,11 @@
               (let ([y (random)])
                 (begin0 y (set! y 5)))))
 
+(test-comp '(lambda (x y) (car x) (unbox y) #f)
+           '(lambda (x y) (car x) (unbox y) (eq? x y)))
+(test-comp '(lambda (x) (car x) #f)
+           '(lambda (x) (car x) (eq? x (box 0))))
+
 (test-comp '(lambda (w) (car w) (mcar w))
            '(lambda (w) (car w) (mcar w) (random)))
 (test-comp '(lambda (w) (car w w))
@@ -1762,6 +1767,13 @@
 (test-comp '(lambda (x) (if (null? x) 1 0) null)
            '(lambda (x) (if (null? x) 1 0) x)
            #f)
+(test-comp '(lambda (x) (if (eq? x '(0)) #t 0))
+           '(lambda (x) (if (eq? x '(0)) (pair? x) 0)))
+(test-comp '(lambda (x) (if (eq? x (list 0)) #t 0))
+           '(lambda (x) (if (eq? x (list 0)) (pair? x) 0)))
+(test-comp '(lambda (x y) (car y) (if (eq? x y) #t 0))
+           '(lambda (x y) (car y) (if (eq? x y) (pair? x) 0)))
+
 
 (test-comp '(lambda (x) (let ([r (something)])
                           (r)))

--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -1702,6 +1702,11 @@
            '(lambda (x) (not (if x #f #t))))
 (test-comp '(lambda (x) (let ([z 2]) (not (if x #f z))))
            '(lambda (x) (let ([z 2]) (not (if x #f #t)))))
+(test-comp '(lambda (z) (when (pair? z) #f))
+           '(lambda (z) (when (pair? z) (not z))))
+(test-comp '(lambda (z) (when (pair? z) (set! z #f) #f))
+           '(lambda (z) (when (pair? z) (set! z #f) (not z)))
+           #f)
 
 (test-comp '(lambda (x) (if x x #f))
            '(lambda (x) x))

--- a/racket/src/racket/src/fun.c
+++ b/racket/src/racket/src/fun.c
@@ -88,6 +88,7 @@ READ_ONLY Scheme_Object *scheme_values_func; /* the function bound to `values' *
 READ_ONLY Scheme_Object *scheme_procedure_p_proc;
 READ_ONLY Scheme_Object *scheme_procedure_arity_includes_proc;
 READ_ONLY Scheme_Object *scheme_void_proc;
+READ_ONLY Scheme_Object *scheme_void_p_proc;
 READ_ONLY Scheme_Object *scheme_check_not_undefined_proc;
 READ_ONLY Scheme_Object *scheme_check_assign_not_undefined_proc;
 READ_ONLY Scheme_Object *scheme_apply_proc;
@@ -507,10 +508,11 @@ scheme_init_fun (Scheme_Env *env)
   scheme_add_global_constant("void", scheme_void_proc, env);
 
   
-  o = scheme_make_folding_prim(void_p, "void?", 1, 1, 1);
-  SCHEME_PRIM_PROC_FLAGS(o) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_IS_UNARY_INLINED
-                                                            | SCHEME_PRIM_IS_OMITABLE);
-  scheme_add_global_constant("void?", o, env);
+  REGISTER_SO(scheme_void_p_proc);
+  scheme_void_p_proc = scheme_make_folding_prim(void_p, "void?", 1, 1, 1);
+  SCHEME_PRIM_PROC_FLAGS(scheme_void_p_proc) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_IS_UNARY_INLINED
+                                                                             | SCHEME_PRIM_IS_OMITABLE);
+  scheme_add_global_constant("void?", scheme_void_p_proc, env);
 
 #ifdef TIME_SYNTAX
   scheme_add_global_constant("time-apply",

--- a/racket/src/racket/src/optimize.c
+++ b/racket/src/racket/src/optimize.c
@@ -4019,6 +4019,7 @@ static void add_types(Scheme_Object *t, Optimize_Info *info, int fuel)
     Scheme_App2_Rec *app = (Scheme_App2_Rec *)t;
     if (SCHEME_PRIMP(app->rator)
         && SAME_TYPE(SCHEME_TYPE(app->rand), scheme_local_type)
+        && !optimize_is_mutated(info, SCHEME_LOCAL_POS(app->rand))
         && relevant_predicate(app->rator)) {
       /* Looks like a predicate on a local variable. Record that the
          predicate succeeded, which may allow conversion of safe
@@ -7400,7 +7401,8 @@ Scheme_Object *scheme_optimize_expr(Scheme_Object *expr, Optimize_Info *info, in
 
       delta = optimize_info_get_shift(info, pos);
 
-      if (context & OPT_CONTEXT_BOOLEAN) {
+      if ((context & OPT_CONTEXT_BOOLEAN)
+          && !optimize_is_mutated(info, pos + delta)) {
         Scheme_Object *pred;
         pred = optimize_get_predicate(pos + delta, info);
         if (pred) {

--- a/racket/src/racket/src/portfun.c
+++ b/racket/src/racket/src/portfun.c
@@ -158,6 +158,7 @@ READ_ONLY static Scheme_Object *default_display_handler;
 READ_ONLY static Scheme_Object *default_write_handler;
 READ_ONLY static Scheme_Object *default_print_handler;
 
+READ_ONLY Scheme_Object *scheme_eof_object_p_proc;
 READ_ONLY Scheme_Object *scheme_default_global_print_handler;
 
 READ_ONLY Scheme_Object *scheme_write_proc;
@@ -335,10 +336,11 @@ scheme_init_port_fun(Scheme_Env *env)
   GLOBAL_NONCM_PRIM("port-count-lines!",              port_count_lines,               1, 1, env);
   GLOBAL_NONCM_PRIM("port-counts-lines?",             port_counts_lines_p,            1, 1, env);
           
-  p = scheme_make_folding_prim(eof_object_p, "eof-object?", 1, 1, 1);
-  SCHEME_PRIM_PROC_FLAGS(p) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_IS_UNARY_INLINED
-                                                            | SCHEME_PRIM_IS_OMITABLE);
-  scheme_add_global_constant("eof-object?", p, env);
+  REGISTER_SO(scheme_eof_object_p_proc);
+  scheme_eof_object_p_proc = scheme_make_folding_prim(eof_object_p, "eof-object?", 1, 1, 1);
+  SCHEME_PRIM_PROC_FLAGS(scheme_eof_object_p_proc) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_IS_UNARY_INLINED
+                                                                                   | SCHEME_PRIM_IS_OMITABLE);
+  scheme_add_global_constant("eof-object?", scheme_eof_object_p_proc, env);
 
   scheme_add_global_constant("write",   scheme_write_proc,    env);
   scheme_add_global_constant("display", scheme_display_proc,  env);

--- a/racket/src/racket/src/schpriv.h
+++ b/racket/src/racket/src/schpriv.h
@@ -439,6 +439,7 @@ extern Scheme_Object *scheme_values_func;
 extern Scheme_Object *scheme_procedure_p_proc;
 extern Scheme_Object *scheme_procedure_arity_includes_proc;
 extern Scheme_Object *scheme_void_proc;
+extern Scheme_Object *scheme_void_p_proc;
 extern Scheme_Object *scheme_syntax_p_proc;
 extern Scheme_Object *scheme_check_not_undefined_proc;
 extern Scheme_Object *scheme_check_assign_not_undefined_proc;
@@ -2445,6 +2446,7 @@ Scheme_Object *scheme_default_prompt_read_handler(int, Scheme_Object *[]);
 Scheme_Object *scheme_default_read_input_port_handler(int argc, Scheme_Object *[]);
 Scheme_Object *scheme_default_read_handler(int argc, Scheme_Object *[]);
 
+extern Scheme_Object *scheme_eof_object_p_proc;
 extern Scheme_Object *scheme_default_global_print_handler;
 
 /* Type readers & writers for compiled code data */


### PR DESCRIPTION
The first commit fix bug, the others are a few new related features.

**1)** When a **mutable** variable with a known type is in a Boolean context, it's incorrectly reduced to `#t`.
This fixes the bug twice (each change is enough to fix it). 
* Don't reduce mutable variables with a type to `#t` in a Boolean context.
* Don't record the type of mutable variables when a predicate is checked in a test condition. (This is more consistent with other parts that record types, like `check_known`.)

**2)** Reduce variables with type `null?` to `null`. The optimizer reduces the variables with a known type to `#t` in a Boolean context. But some predicates imply that the variable has a definite value, so they can be reduced in a non-Boolean context too. For example, in `(lambda (x) (if (null? x) x 0)))` reduce the last `x` to `null`.
This also adds `void? ` and `eof-object? ` to the relevant predicates list and when a variable has these types reduce it to `#<void>` or `eof` respectively.

**3)** Infer type from `eq?` comparisons in test positions. For emple, in `(if (eq? x <pred?-expr>) <tbranch> <fbranch>)` infer that the type of `x` is `pred?` in the `<tbranch>`. This extends the previous type inference that recorded types from constructions like `(if (pred? x) <tbranch> <fbranch>)`.
This also, reduce `(eq? x y)` to `#f` when the types of `x` and `y` are different, to reduce the unnecessary types recording.

 *[Note: This idea can be extended to handle `equal?` and `eqv?`, but the relevant predicates list is not guaranty to be `equal?-disjoint` in the future, so I used only `eq?`.]*

**4)** Add `not` to the relevant predicates list. Previously all the predicates recognized only `non-#f` things, so `not` can be safely added to the list of disjoint predicates. But many of the parts of the optimizer relied on the `non-#f` property and had to be modified.
This also records that in `(if x <tbranch> <fbranch>)` the type of `x` is `not` in the `<fbranch>` so it can be reduced to `#f`.
