### PR TITLE
Fix typos in docs

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/module-basics.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/module-basics.scrbl
@@ -113,7 +113,7 @@ Racket tools all work automatically with relative paths. For example,
 
 @commandline{racket sort.rkt}
 
-on the comamnd line runs the @filepath{sort.rkt} program and
+on the command line runs the @filepath{sort.rkt} program and
 automatically loads and compiles required modules. With a large enough
 program, compilation from source can take too long, so use
 

--- a/pkgs/racket-doc/scribblings/reference/custom-ports.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/custom-ports.scrbl
@@ -51,7 +51,7 @@ written.
 
 Creates an input port, which is immediately open for reading. If
 @racket[close] procedure has no side effects, then the port need not
-be explicitly closed. See also @racket[make-input-port/peek-to-read].
+be explicitly closed. See also @racket[make-input-port/read-to-peek].
 
 The arguments implement the port as follows:
 
@@ -216,8 +216,8 @@ The arguments implement the port as follows:
     @elemref["special"]{special} when @racket[peek] is
     @racket[#f]. Finally, the automatic peek implementation is
     incompatible with progress events, so if @racket[peek] is
-    @racket[#f], then @racket[progress-evt] and @racket[commit] must
-    be @racket[#f]. See also @racket[make-input-port/peek-to-read],
+    @racket[#f], then @racket[get-progress-evt] and @racket[commit] must
+    be @racket[#f]. See also @racket[make-input-port/read-to-peek],
     which implements peeking in terms of @racket[read-in] without
     these constraints.
 


### PR DESCRIPTION
This closes [PR 15093](http://bugs.racket-lang.org/query/?cmd=view%20audit-trail&database=default&pr=15093) (the name of the function is `make-input-port/*read*-to-peek`, not `make-input-port/peek-to-*read*`. 

This also fixs the first item of [PR15109](http://bugs.racket-lang.org/query/?cmd=view%20audit-trail&database=default&pr=15109).