### PR TITLE
Remove innecesary wraps in values

### DIFF
--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -1563,6 +1563,17 @@
 (test-comp '(lambda (w) (if (void (list w)) 1 2))
            '(lambda (w) 1))
 
+; Diferent number of argumets use different codepaths
+(test-comp '(lambda (f x) (void))
+           '(lambda (f x) (void (list))))
+(test-comp '(lambda (f x) (begin (values (f x)) (void)))
+           '(lambda (f x) (void (list (f x)))))
+(test-comp '(lambda (f x) (begin (values (f x)) (values (f x)) (void)))
+           '(lambda (f x) (void (list (f x) (f x)))))
+(test-comp '(lambda (f x) (begin (values (f x)) (values (f x)) (values (f x)) (void)))
+           '(lambda (f x) (void (list (f x) (f x) (f x)))))
+
+
 (test null
       call-with-values (lambda () (with-continuation-mark 'a 'b (values))) list)
 

--- a/racket/src/racket/src/portfun.c
+++ b/racket/src/racket/src/portfun.c
@@ -242,20 +242,20 @@ scheme_init_port_fun(Scheme_Env *env)
   GLOBAL_FOLDING_PRIM("string-port?",           string_port_p,              1, 1, 1, env);
   GLOBAL_FOLDING_PRIM("terminal-port?",         scheme_terminal_port_p,     1, 1, 1, env);
 
-  GLOBAL_PRIM_W_ARITY("port-closed?",           port_closed_p,          1, 1, env); 
-  GLOBAL_PRIM_W_ARITY("open-input-file",        open_input_file,        1, 3, env);
-  GLOBAL_PRIM_W_ARITY("open-input-bytes",       open_input_byte_string, 1, 2, env);
-  GLOBAL_PRIM_W_ARITY("open-input-string",      open_input_char_string, 1, 2, env);
-  GLOBAL_PRIM_W_ARITY("open-output-file",       open_output_file,       1, 3, env);
-  GLOBAL_PRIM_W_ARITY("open-output-bytes",      open_output_string,     0, 1, env);
-  GLOBAL_PRIM_W_ARITY("open-output-string",     open_output_string,     0, 1, env);
-  GLOBAL_PRIM_W_ARITY("get-output-bytes",       get_output_byte_string, 1, 4, env);
-  GLOBAL_PRIM_W_ARITY("get-output-string",      get_output_char_string, 1, 1, env);
-  GLOBAL_PRIM_W_ARITY("open-input-output-file", open_input_output_file, 1, 3, env);
-  GLOBAL_PRIM_W_ARITY("close-input-port",       close_input_port,       1, 1, env);
-  GLOBAL_PRIM_W_ARITY("close-output-port",      close_output_port,      1, 1, env);
-  GLOBAL_PRIM_W_ARITY("make-input-port",        make_input_port,        4, 10, env);
-  GLOBAL_PRIM_W_ARITY("make-output-port",       make_output_port,       4, 11, env);
+  GLOBAL_NONCM_PRIM("port-closed?",             port_closed_p,          1, 1, env); 
+  GLOBAL_NONCM_PRIM("open-input-file",          open_input_file,        1, 3, env);
+  GLOBAL_NONCM_PRIM("open-input-bytes",         open_input_byte_string, 1, 2, env);
+  GLOBAL_NONCM_PRIM("open-input-string",        open_input_char_string, 1, 2, env);
+  GLOBAL_NONCM_PRIM("open-output-file",         open_output_file,       1, 3, env);
+  GLOBAL_NONCM_PRIM("open-output-bytes",        open_output_string,     0, 1, env);
+  GLOBAL_NONCM_PRIM("open-output-string",       open_output_string,     0, 1, env);
+  GLOBAL_NONCM_PRIM("get-output-bytes",         get_output_byte_string, 1, 4, env);
+  GLOBAL_NONCM_PRIM("get-output-string",        get_output_char_string, 1, 1, env);
+  GLOBAL_NONCM_PRIM("open-input-output-file",   open_input_output_file, 1, 3, env);
+  GLOBAL_NONCM_PRIM("close-input-port",         close_input_port,       1, 1, env);
+  GLOBAL_NONCM_PRIM("close-output-port",        close_output_port,      1, 1, env);
+  GLOBAL_NONCM_PRIM("make-input-port",          make_input_port,        4, 10, env);
+  GLOBAL_NONCM_PRIM("make-output-port",         make_output_port,       4, 11, env);
   
   GLOBAL_PRIM_W_ARITY2("call-with-output-file", call_with_output_file,  2, 4, 0, -1, env);
   GLOBAL_PRIM_W_ARITY2("call-with-input-file",  call_with_input_file,   2, 3, 0, -1, env);
@@ -264,7 +264,7 @@ scheme_init_port_fun(Scheme_Env *env)
   GLOBAL_PRIM_W_ARITY2("load",                  load,                   1, 1, 0, -1, env);
   GLOBAL_PRIM_W_ARITY2("make-pipe",             sch_pipe,               0, 3, 2,  2, env);
   GLOBAL_PRIM_W_ARITY2("port-next-location",    port_next_location,     1, 1, 3,  3, env);
-  GLOBAL_PRIM_W_ARITY("set-port-next-location!",  set_port_next_location, 4, 4, env);
+  GLOBAL_NONCM_PRIM("set-port-next-location!",  set_port_next_location, 4, 4, env);
 
   GLOBAL_PRIM_W_ARITY("filesystem-change-evt",  filesystem_change_evt,   1, 2, env);
   GLOBAL_NONCM_PRIM("filesystem-change-evt?",   filesystem_change_evt_p, 1, 1, env);


### PR DESCRIPTION
While reducing some ignored expressions, the optimizer may wrap the arguments `<expr>` in `(values <expr>)` when it isn't sure that they are single-value non-cm expression. 


1) Many of the portfun.c primitives are defined with `GLOBAL_PRIM_W_ARITY` but I think they can be defined with  `GLOBAL_NONCM_PRIM`. The only exception is `filesystem-change-evt` because it may tailcall a thunk in case of an error. The most common case is `(values (get-output-string x))`.

2) The expression `(values ...)` is non-cm, but the number of return values is clearly variable. But in case it has only one argument, it can be marked as singled valued too. This eliminate the construction of same expressions like `(values (values (f))`.

I didn't see too many cases where 3) and 4) are relevant, but they are quite straightforward.

3) To check that `(if <t> <tb> <fb>)` is a s-v-noncm it's enough to check `<tb>` and `<fb>` are. If `<t>` is not singled-valued, then it will generate an error that will get caught elsewhere.

4) Add the cases for `begin` and `begin0` to the s-v-noncm test, and makes the code of the `let` more general. With this change, it jumps directly to the tail of a `begin` or `let` form, so the same level of fuel allows more nesting.
