### PR TITLE
FreeBSD/arm support

### DIFF
--- a/racket/src/racket/sconfig.h
+++ b/racket/src/racket/sconfig.h
@@ -441,7 +441,7 @@
 
 #endif
 
-  /************** FreeBSD with gcc ****************/
+  /************** FreeBSD with clang ****************/
 
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
 

--- a/racket/src/racket/sconfig.h
+++ b/racket/src/racket/sconfig.h
@@ -466,6 +466,8 @@
 # elif defined(__sparc64__)
 #  define SCHEME_PLATFORM_LIBRARY_SUBPATH "sparc64-freebsd"
 #  define FLUSH_SPARC_REGISTER_WINDOWS
+# elif defined(__arm__)
+#  define SCHEME_PLATFORM_LIBRARY_SUBPATH "arm-freebsd"
 # else
 #  error Unported platform.
 # endif


### PR DESCRIPTION
These changes enable compilation on FreeBSD/arm.  The ARM JIT compiler doesn't work on this platform (it crashes, I did not investigate).

```
racket/racket/bin % ./racket   
Welcome to Racket v6.2.900.5.
> (displayln "hello world")
hello world
> ^D
racket/racket/bin % uname -srm
FreeBSD 11.0-CURRENT arm

```