### PR TITLE
Provide `promise/name?`.

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/promise.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/promise.scrbl
@@ -80,6 +80,12 @@ If a @racket[delay/name] promise forces itself, no exception is
 raised, the promise is never considered ``running'' or ``forced'' in
 the sense of @racket[promise-running?] and @racket[promise-forced?].}
 
+@defproc[(promise/name? [promise any/c]) boolean?]{
+
+Returns @racket[#t] if @racket[promise] is a promise created with @racket[delay/name].
+@history[#:added "6.2.900.5"]
+}
+
 @defform[(delay/strict body ...+)]{
 
 Creates a ``strict'' promise: it is evaluated immediately, and the

--- a/racket/collects/racket/promise.rkt
+++ b/racket/collects/racket/promise.rkt
@@ -7,7 +7,7 @@
 
 (define-struct (promise/name promise) ()
   #:property prop:force (λ(p) ((pref p))))
-(provide (rename-out [delay/name* delay/name]))
+(provide (rename-out [delay/name* delay/name]) promise/name?)
 (define delay/name make-promise/name)
 (define-syntax (delay/name* stx) (make-delayer stx #'delay/name '()))
 


### PR DESCRIPTION
This is needed for Typed Racket, since by-name promises are not
idempotent and thus can't be typed like existing promises.
Therefore, the contract for `(Promiseof T)` needs to reject
them.

In particular, see racket/typed-racket#159.