### PR TITLE
Jitinline string-length and bytes-length

### DIFF
--- a/racket/src/racket/src/jit.h
+++ b/racket/src/racket/src/jit.h
@@ -313,6 +313,8 @@ struct scheme_jit_common_record {
   void *bad_vector_length_code;
   void *bad_flvector_length_code;
   void *bad_fxvector_length_code;
+  void *bad_string_length_code;
+  void *bad_bytes_length_code;
   void *vector_ref_code, *vector_ref_check_index_code, *vector_set_code, *vector_set_check_index_code;
   void *chap_vector_ref_code, *chap_vector_ref_check_index_code, *chap_vector_set_code, *chap_vector_set_check_index_code;
   void *string_ref_code, *string_ref_check_index_code, *string_set_code, *string_set_check_index_code;

--- a/racket/src/racket/src/jit_ts.c
+++ b/racket/src/racket/src/jit_ts.c
@@ -89,6 +89,8 @@ define_ts_s_s(scheme_flvector_length, FSRC_MARKS)
 define_ts_s_s(scheme_extflvector_length, FSRC_MARKS)
 #endif
 define_ts_s_s(scheme_fxvector_length, FSRC_MARKS)
+define_ts_s_s(scheme_string_length, FSRC_MARKS)
+define_ts_s_s(scheme_byte_string_length, FSRC_MARKS)
 define_ts_s_s(scheme_unbox, FSRC_MARKS)
 define_ts_si_s(scheme_struct_ref, FSRC_MARKS)
 define_ts_sis_v(scheme_struct_set, FSRC_MARKS)
@@ -207,6 +209,8 @@ define_ts_s_s(scheme_box, FSRC_OTHER)
 # define ts_scheme_extflvector_length scheme_extflvector_length
 #endif
 # define ts_scheme_fxvector_length scheme_fxvector_length
+# define ts_scheme_string_length scheme_string_length
+# define ts_scheme_byte_string_length scheme_byte_string_length
 # define ts_scheme_struct_ref scheme_struct_ref
 # define ts_scheme_struct_set scheme_struct_set
 # define ts_scheme_equal scheme_equal

--- a/racket/src/racket/src/jitcommon.c
+++ b/racket/src/racket/src/jitcommon.c
@@ -603,6 +603,28 @@ static int common1b(mz_jit_state *jitter, void *_data)
   CHECK_LIMIT();
   scheme_jit_register_sub_func(jitter, sjc.bad_fxvector_length_code, scheme_false);
 
+  /* *** bad_string_length_code *** */
+  /* R0 is argument */
+  sjc.bad_string_length_code = jit_get_ip();
+  mz_prolog(JIT_R1);
+  JIT_UPDATE_THREAD_RSPTR_IF_NEEDED();
+  jit_prepare(1);
+  jit_pusharg_p(JIT_R0);
+  (void)mz_finish_lwe(ts_scheme_string_length, ref);
+  CHECK_LIMIT();
+  scheme_jit_register_sub_func(jitter, sjc.bad_string_length_code, scheme_false);
+
+  /* *** bad_bytes_length_code *** */
+  /* R0 is argument */
+  sjc.bad_bytes_length_code = jit_get_ip();
+  mz_prolog(JIT_R1);
+  JIT_UPDATE_THREAD_RSPTR_IF_NEEDED();
+  jit_prepare(1);
+  jit_pusharg_p(JIT_R0);
+  (void)mz_finish_lwe(ts_scheme_byte_string_length, ref);
+  CHECK_LIMIT();
+  scheme_jit_register_sub_func(jitter, sjc.bad_bytes_length_code, scheme_false);
+
   return 1;
 }
 

--- a/racket/src/racket/src/string.c
+++ b/racket/src/racket/src/string.c
@@ -496,7 +496,8 @@ scheme_init_string (Scheme_Env *env)
 			     env);
   
   p = scheme_make_folding_prim(string_length, "string-length", 1, 1, 1);
-  SCHEME_PRIM_PROC_FLAGS(p) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_PRODUCES_FIXNUM);
+  SCHEME_PRIM_PROC_FLAGS(p) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_IS_UNARY_INLINED
+                                                            |SCHEME_PRIM_PRODUCES_FIXNUM);
   scheme_add_global_constant("string-length", p,
 			     env);
 
@@ -774,7 +775,8 @@ scheme_init_string (Scheme_Env *env)
   GLOBAL_PRIM_W_ARITY("shared-bytes", shared_byte_string, 0, -1, env);
 
   p = scheme_make_folding_prim(byte_string_length, "bytes-length", 1, 1, 1);
-  SCHEME_PRIM_PROC_FLAGS(p) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_PRODUCES_FIXNUM);
+  SCHEME_PRIM_PROC_FLAGS(p) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_IS_UNARY_INLINED
+                                                            |SCHEME_PRIM_PRODUCES_FIXNUM);
   scheme_add_global_constant("bytes-length", p, env);
 
   p = scheme_make_immed_prim(scheme_checked_byte_string_ref, "bytes-ref", 2, 2);


### PR DESCRIPTION
Previously only the `unsafe-X-length` versions were inlined in the jit compiler.

(I didn't write jit code before, I hope I got all the details correctly.)

One small detail is the name conventions of the the intermediate constructions. At the C level the names are `char_string` and `byte_string`, but they are renamed at the Racket level as `string` and `bytes`. So I'm not sure if `bad_string_length_code` and `bad_bytes_length_code` are the best names election.