### PR TITLE
Fix check-syntax arrows within units

### DIFF
--- a/racket/collects/racket/unit.rkt
+++ b/racket/collects/racket/unit.rkt
@@ -942,7 +942,7 @@
        ;; the introduced parts, which we implement by adding the
        ;; mark to the introduced parts and then flipping it
        ;; evenrywehere.
-       (define intro (make-syntax-introducer))
+       (define intro (make-syntax-introducer #t))
        
        (with-syntax ((((dept . depr) ...)
                       (map


### PR DESCRIPTION
Programs like this now show check-syntax arrows in DrRacket from the `x` definition outside the unit to the `x` in the unit body, and from the `y` definition inside the unit to the `y` in the `(define z y)`, where before both were broken.
```racket
#lang racket
(define x 3)
x
(define-signature z^ (z))
(define-unit z@
  (import)
  (export z^)
  (define y x)
  (define z y))
```