### PR TITLE
Fix match with (list-no-order p ..k) patterns

### DIFF
--- a/pkgs/racket-test/tests/match/examples.rkt
+++ b/pkgs/racket-test/tests/match/examples.rkt
@@ -202,6 +202,26 @@
            [(list-no-order 1 2 3 rest ...) rest]
            [_ 'no]))
 
+   (comp '(x y z)
+         (match '(1 x 2 y 3 z)
+           [(list-no-order 1 2 3 rest ..1) rest]
+           [_ 'no]))
+
+   (comp '(x y z)
+         (match '(1 x 2 y 3 z)
+           [(list-no-order 1 2 3 rest ..2) rest]
+           [_ 'no]))
+
+   (comp '(x y z)
+         (match '(1 x 2 y 3 z)
+           [(list-no-order 1 2 3 rest ..3) rest]
+           [_ 'no]))
+
+   (comp 'no
+         (match '(1 x 2 y 3 z)
+           [(list-no-order 1 2 3 rest ..4) rest]
+           [_ 'no]))
+
    (comp
     'yes
     (match '(a (c d))

--- a/racket/collects/racket/match/parse.rkt
+++ b/racket/collects/racket/match/parse.rkt
@@ -101,12 +101,11 @@
      (ddk? #'dd)
      (let* ([count (ddk? #'dd)]
             [min (if (number? count) count #f)]
-            [max (if (number? count) count #f)]
             [ps (syntax->list #'(p ...))])
        (GSeq (cons (list (rearm+parse #'lp))
                         (for/list ([p ps]) (list (parse p))))
                   (cons min (map (lambda _ 1) ps))
-                  (cons max (map (lambda _ 1) ps))
+                  (cons #f (map (lambda _ 1) ps))
                   ;; vars in lp are lists, vars elsewhere are not
                   (cons #f (map (lambda _ #t) ps))
                   (Null (Dummy (syntax/loc stx _)))


### PR DESCRIPTION
`p ..k` matches exactly k repetitions of p, but its documented behavior is to match "k or more" repetitions. This fix implements the documented behavior, and adds tests for this.

Fixes [bug number 15122](http://bugs.racket-lang.org/query/?debug=&database=default&cmd=view+audit-trail&cmd=view&pr=15122).
