### PR TITLE
Fix an error in racket-test-core/number.rktl on OpenBSD-current/sparc64

### DIFF
--- a/racket/src/racket/sconfig.h
+++ b/racket/src/racket/sconfig.h
@@ -378,6 +378,7 @@
 #  define MZ_USE_JIT_PPC
 # elif defined(__sparc64__)
 #  define FLUSH_SPARC_REGISTER_WINDOWS
+#  define FMOD_CAN_RETURN_POS_ZERO
 # elif defined(__arm__)
 #  define MZ_USE_JIT_ARM
 #  define FFI_CALLBACK_NEED_INT_CLEAR


### PR DESCRIPTION
"Errors were:
(Section (got expected (call)))
((numbers) (0.0 -0.0 (#<procedure:round> -0.0)))
((numbers) (125.0+0.0i 125.0-0.0i (#<procedure:z-round> 125.00000000000023-0.0i)))
((numbers) (100.0+0.0i 100.0-0.0i (#<procedure:z-round> 99.99999999999999-0.0i)))"

I tried every applicable option to OpenBSD/sparc64 in "Inexact Arithmetic", and this is the only one which fixed the error.