### PR TITLE
Use scheme_getenv in eval.c

### DIFF
--- a/racket/src/racket/src/eval.c
+++ b/racket/src/racket/src/eval.c
@@ -382,7 +382,7 @@ scheme_init_eval (Scheme_Env *env)
   GLOBAL_PARAMETER("eval-jit-enabled",                  use_jit,                  MZCONFIG_USE_JIT,               env);
   GLOBAL_PARAMETER("compile-context-preservation-enabled", disallow_inline,       MZCONFIG_DISALLOW_INLINE,       env);
 
-  if (getenv("PLT_VALIDATE_COMPILE")) {
+  if (scheme_getenv("PLT_VALIDATE_COMPILE")) {
     /* Enables validation of bytecode as it is generated,
        to double-check that the compiler is producing
        valid bytecode as it should. */
@@ -392,7 +392,7 @@ scheme_init_eval (Scheme_Env *env)
   {
     /* Enables re-running the optimizer N times on every compilation. */
     const char *s;
-    s = getenv("PLT_RECOMPILE_COMPILE");
+    s = scheme_getenv("PLT_RECOMPILE_COMPILE");
     if (s) {
       int i = 0;
       while ((s[i] >= '0') && (s[i] <= '9')) {


### PR DESCRIPTION
Replace `getenv` with `scheme_getenv` to read some environment variables. IIRC this is different only when the variable has an non ascii character like `é` or `ñ`, that is not an expected usecase of these variables. Anyway I think that it's better to make this change for consistency.