### PR TITLE
Fix string-replace when the string is mutable

### DIFF
--- a/pkgs/racket-test-core/tests/racket/string.rktl
+++ b/pkgs/racket-test-core/tests/racket/string.rktl
@@ -483,4 +483,11 @@
   (test "foo\\1bar" string-replace "foo===bar" #rx"(=+)" "\\1")
   (test "foo\\1bar" string-replace "foo===bar" #px"={3}" "\\1"))
 
+;test that mutable string are not cached incorrectly
+(let ([str (string-copy "_1_")])
+  (test "!!! _2_" string-replace "_1_ _2_" str "!!!") ;add str to the internal cache
+  (string-set! str 1 #\2)
+  (test "_1_ !!!" string-replace "_1_ _2_" str "!!!") ;verify that the new str is used
+)
+
 (report-errs)


### PR DESCRIPTION
The `from` string argument is converted to a regexp and cached. When `from` is
a mutable string this can cause wrong results in the following calls
to `string-replace`. So the string is first converted to an immutable string to
be used as the key for the cache.

The cache has two steps:
A mutable string weakly holds a immutable copy until it is collected
or modified (and used as a argument of `string-replace`).
The immutable copy weakly holds the regexp that is used in string-replace.
Using `string->immutable-string` directly in `string-replace` is not a useful
because the immutable copy could be immediately collected.