### PR TITLE
write-xexpr: consistently use argument port.

### DIFF
--- a/racket/collects/xml/private/xexpr.rkt
+++ b/racket/collects/xml/private/xexpr.rkt
@@ -131,7 +131,7 @@
          (write-string/escape (cadr att) escape-attribute-table out)
          (write-string "\"" out))
        (when insert-newlines?
-         (newline))
+         (newline out))
        ; Write end of opening tag
        (if (and (null? content)
                 (case short


### PR DESCRIPTION
Fix the behavior of the `#:insert-newlines?` keyword argument, to write newlines to the argument port, rather than `(current-output-port)`.