### PR TITLE
Fix unresolve_expr_2 for closures

### DIFF
--- a/racket/src/racket/src/resolve.c
+++ b/racket/src/racket/src/resolve.c
@@ -4473,6 +4473,11 @@ static Scheme_Object *unresolve_expr_2(Scheme_Object *e, Unresolve_Info *ui, int
     }
   case scheme_closure_type:
     {
+      if (!ui->closures) {
+        Scheme_Hash_Table *ht;
+        ht = scheme_make_hash_table(SCHEME_hash_ptr);
+        ui->closures = ht;
+      }
       return unresolve_closure(e, ui);
     }
   case scheme_unclosed_procedure_type:


### PR DESCRIPTION
I'm getting a crash when recompiling `lambdas`, for example:

    #lang racket/base
    (compiled-expression-recompile (compile #'(lambda () 5)))

This patch apparently fixes the error, but I'm not sure about the details. The code is copied from `scheme_resolve_expr`.

Fixes [PR15133](http://bugs.racket-lang.org/query/?cmd=view%20audit-trail&database=default&pr=15133).

--

Also, I get a strange result recompiling a module, because the imported functions are unnecessary checked. I think that it's unrelated. For example with 

    (module x racket 
      (define (r z) (reverse z))

Compiling once I get something equivalent to

    (module x racket
      (define-values (r)
         (lambda (z) (alt-reverse (#%sfs-clear z)))))

Compiling twice I get something equivalent to

    (module x racket
      (define-values (r)
         (lambda (z) ((#%checked alt-reverse) (#%sfs-clear z)))))
