### PR TITLE
Bug fix for calculating init-dependencies when subtyping is involved.

### DIFF
--- a/pkgs/racket-test/tests/units/test-unit.rkt
+++ b/pkgs/racket-test/tests/units/test-unit.rkt
@@ -2199,3 +2199,16 @@
                                         [(s x y) (list x y)]))
                                  S))))))
   
+;; Make sure init-dependencies are calculated correctly in the presence of subtyping
+(let ()
+  (define-signature a1^ (a1))
+  (define-signature a2^ extends a1^ (a2))
+  (define-unit u (import a1^) (export) (init-depend a1^) a1)
+  (define v
+    (compound-unit/infer
+     (import [A2 : a2^])
+     (export)
+     (link (() u A2))))
+  (define a1 1)
+  (define a2 2)
+  (test 1 (invoke-unit v (import a2^))))

--- a/racket/collects/racket/unit.rkt
+++ b/racket/collects/racket/unit.rkt
@@ -2181,8 +2181,8 @@
                  (for/or ([lr (in-list sub-in)])
                    (and (eq? (link-record-tag lr)
                              (car dep))
-                        (free-identifier=? (link-record-sigid lr)
-                                           (cdr dep))
+                        (siginfo-subtype (signature-siginfo (lookup-signature (link-record-sigid lr)))
+                                         (signature-siginfo (lookup-signature (cdr dep))))
                         lr)))
                ;; If `lr` refers to an import, then propoagate the dependency.
                ;; If it refers to a linked unit, make sure that unit is earlier.


### PR DESCRIPTION
I think this fixes Problem Report: 15139[1], which allows the following program to run without error:

#lang racket
(define-signature a1^ (a1))
(define-signature a2^ extends a1^ (a2))
(define-unit u (import a1^) (export) (init-depend a1^))
(compound-unit/infer
  (import  [A : a2^])
  (export)
  (link (() u A)))

Previously the init-depend calculation did not consider subtyping signature subtyping correctly.

[1]: http://bugs.racket-lang.org/query/?cmd=view&pr=15139