### PR TITLE
Add syntax property with static init-depend information to compound-unit/infer results

### DIFF
--- a/racket/collects/racket/private/unit-compiletime.rkt
+++ b/racket/collects/racket/private/unit-compiletime.rkt
@@ -599,13 +599,10 @@
 ;; This utility function returns a list of natural numbers for use as a syntax
 ;; property needed to support units in Typed Racket
 (define (build-init-depend-property init-depends imports)
-  ;; Typed Racket does not support tagged imports or exports
-  ;; so drop the tags from init-depends and imports
-  (let ([id-sigs (map cdr init-depends)]
-        [import-sigs (map cdr imports)])
-    (let loop ([i 0] [imports import-sigs])
-      (cond
-        [(null? imports) '()]
-        [else (if (member (car imports) id-sigs free-identifier=?)
-                  (cons i (loop (add1 i) (cdr imports)))
-                  (loop (add1 i) (cdr imports)))]))))
+  (define (sig=? s1 s2)
+    (and (eq? (syntax-e (car s1)) (car s2))
+         (free-identifier=? (cdr s1) (cdr s2))))
+  (for/list ([import (in-list imports)]
+             [index (in-naturals)]
+             #:when (member import init-depends sig=?))
+    index))

--- a/racket/collects/racket/private/unit-compiletime.rkt
+++ b/racket/collects/racket/private/unit-compiletime.rkt
@@ -598,6 +598,8 @@
 
 ;; This utility function returns a list of natural numbers for use as a syntax
 ;; property needed to support units in Typed Racket
+;; Each number in the list is an index into a unit's list of imports signifying
+;; that the import at that index is also an init-dependency of the unit
 (define (build-init-depend-property init-depends imports)
   (define (sig=? s1 s2)
     (and (eq? (syntax-e (car s1)) (car s2))

--- a/racket/collects/racket/private/unit-compiletime.rkt
+++ b/racket/collects/racket/private/unit-compiletime.rkt
@@ -22,7 +22,8 @@
          map-sig split-requires split-requires* apply-mac complete-exports complete-imports check-duplicate-subs
          process-spec
          make-relative-introducer
-         bind-at)
+         bind-at
+         build-init-depend-property)
 
 (define-syntax (apply-mac stx)
   (syntax-case stx ()
@@ -594,3 +595,17 @@
          sstx
          (cons unbox-stx #'x)
          sstx)]))))
+
+;; This utility function returns a list of natural numbers for use as a syntax
+;; property needed to support units in Typed Racket
+(define (build-init-depend-property init-depends imports)
+  ;; Typed Racket does not support tagged imports or exports
+  ;; so drop the tags from init-depends and imports
+  (let ([id-sigs (map cdr init-depends)]
+        [import-sigs (map cdr imports)])
+    (let loop ([i 0] [imports import-sigs])
+      (cond
+        [(null? imports) '()]
+        [else (if (member (car imports) id-sigs free-identifier=?)
+                  (cons i (loop (add1 i) (cdr imports)))
+                  (loop (add1 i) (cdr imports)))]))))

--- a/racket/collects/racket/unit.rkt
+++ b/racket/collects/racket/unit.rkt
@@ -1675,7 +1675,7 @@
                                   (sub-tmp (equal-hash-table sub-in-key-code-workaround ...))
                                   ...)
                                 (unit-export ((export-key ...) export-code) ...)))))))
-               'tr:inferred-init-depend-property
+               'inferred-init-depends
                (build-init-depend-property
                 static-dep-info
                 (map syntax-e (syntax->list #'((import-tag . import-sigid) ...)))))

--- a/racket/collects/racket/unit.rkt
+++ b/racket/collects/racket/unit.rkt
@@ -1648,7 +1648,9 @@
               ;; Attach a syntax-property containing indices of init-depends signatures
               ;; for this compound unit. Although this property is attached to all
               ;; compound-units, it is only meaningful when the compound unit was
-              ;; created via compound-unit/infer
+              ;; created via compound-unit/infer. Only the `inferred` dependencies
+              ;; will appear in this syntax property, when no inference occurs the property
+              ;; will contain an empty list.
               (syntax-property
                (quasisyntax/loc (error-syntax)
                  (let ([deps '()]

--- a/racket/collects/racket/unit.rkt
+++ b/racket/collects/racket/unit.rkt
@@ -1645,29 +1645,34 @@
                            (syntax->list #'((((sub-in-key sub-in-code) ...) ...) ...))))
                          )
              (values
-              (quasisyntax/loc (error-syntax)
-                (let ([deps '()]
-                      [sub-tmp sub-exp] ...)
-                  check-sub-exp ...
-                  (make-unit
-                   'name
-                   (vector-immutable
-                    (cons 'import-name
-                          (vector-immutable import-key ...))
-                    ...)
-                   (vector-immutable
-                    (cons 'export-name
-                          (vector-immutable export-key ...))
-                    ...)
-                   deps
-                   (lambda ()
-                     (let-values ([(sub-tmp sub-export-table-tmp) ((unit-go sub-tmp))]
+              (syntax-property
+               (quasisyntax/loc (error-syntax)
+                 (let ([deps '()]
+                       [sub-tmp sub-exp] ...)
+                   check-sub-exp ...
+                   (make-unit
+                    'name
+                    (vector-immutable
+                     (cons 'import-name
+                           (vector-immutable import-key ...))
+                     ...)
+                    (vector-immutable
+                     (cons 'export-name
+                           (vector-immutable export-key ...))
+                     ...)
+                    deps
+                    (lambda ()
+                      (let-values ([(sub-tmp sub-export-table-tmp) ((unit-go sub-tmp))]
+                                   ...)
+                        (values (lambda (import-table-id)
+                                  (void)
+                                  (sub-tmp (equal-hash-table sub-in-key-code-workaround ...))
                                   ...)
-                       (values (lambda (import-table-id)
-                                 (void)
-                                 (sub-tmp (equal-hash-table sub-in-key-code-workaround ...))
-                                 ...)
-                               (unit-export ((export-key ...) export-code) ...)))))))
+                                (unit-export ((export-key ...) export-code) ...)))))))
+               'tr:inferred-init-depend-property
+               (build-init-depend-property
+                static-dep-info
+                (map syntax-e (syntax->list #'((import-tag . import-sigid) ...)))))
               (map syntax-e (syntax->list #'((import-tag . import-sigid) ...)))
               (map syntax-e (syntax->list #'((export-tag . export-sigid) ...)))
               static-dep-info))))))

--- a/racket/collects/racket/unit.rkt
+++ b/racket/collects/racket/unit.rkt
@@ -1645,6 +1645,10 @@
                            (syntax->list #'((((sub-in-key sub-in-code) ...) ...) ...))))
                          )
              (values
+              ;; Attach a syntax-property containing indices of init-depends signatures
+              ;; for this compound unit. Although this property is attached to all
+              ;; compound-units, it is only meaningful when the compound unit was
+              ;; created via compound-unit/infer
               (syntax-property
                (quasisyntax/loc (error-syntax)
                  (let ([deps '()]


### PR DESCRIPTION
This PR adds a syntax property to the expansion of compound-unit and compound-unit/infer expressions, containing a list of indices referring to which imports are inferred as init-dependencies of the compound-unit.

The property attached to compound-units that are not created via compound-unit/infer is '(). 

This syntax property is needed to support units in Typed Racket, and is used in racket/typed-racket#190