### PR TITLE
http-client: don't try to gunzip an empty stream

### DIFF
--- a/racket/collects/net/http-client.rkt
+++ b/racket/collects/net/http-client.rkt
@@ -261,7 +261,9 @@
   (define decoded-response-port
     (cond
       [head? raw-response-port]
-      [(and (memq 'gzip decodes) (regexp-member #rx#"^(?i:Content-Encoding: +gzip)$" headers))
+      [(and (memq 'gzip decodes)
+            (regexp-member #rx#"^(?i:Content-Encoding: +gzip)$" headers)
+            (not (eof-object? (peek-byte raw-response-port))))
        (define-values (in out) (make-pipe PIPE-SIZE))
        (define gunzip-t
          (thread


### PR DESCRIPTION
Per (brief) discussion on mailing list, this change adjusts http-recv! to not try to gunzip a stream if it's empty; just return it as the empty stream.