### PR TITLE
net: make #<url> structure transparent

### DIFF
--- a/racket/collects/net/http-client.rkt
+++ b/racket/collects/net/http-client.rkt
@@ -261,7 +261,9 @@
   (define decoded-response-port
     (cond
       [head? raw-response-port]
-      [(and (memq 'gzip decodes) (regexp-member #rx#"^(?i:Content-Encoding: +gzip)$" headers))
+      [(and (memq 'gzip decodes)
+            (regexp-member #rx#"^(?i:Content-Encoding: +gzip)$" headers)
+            (not (eof-object? (peek-byte raw-response-port))))
        (define-values (in out) (make-pipe PIPE-SIZE))
        (define gunzip-t
          (thread

--- a/racket/collects/net/url-structs.rkt
+++ b/racket/collects/net/url-structs.rkt
@@ -3,7 +3,8 @@
 
 (define-serializable-struct url
   (scheme user host port path-absolute? path query fragment)
-  #:mutable)
+  #:mutable
+  #:transparent)
 (define-serializable-struct path/param (path param))
 
 (provide/contract


### PR DESCRIPTION
As I mentioned in an email thread on racket-users, it was a great help to me to make this structure transparent; it seems quite "Racket-y" to do so, and I don't see any drawbacks (since the constructor is already exposed, and url->string and string->url both exist).

@jeapostrophe , I think this is again your part of the world...