### PR TITLE
Remove ignored call/cc

### DIFF
--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -3540,6 +3540,16 @@
            #f)
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Check that the unused continuations are removed
+
+(test-comp '(call-with-current-continuation (lambda (ignored) 5))
+           5)
+(test-comp '(call-with-composable-continuation (lambda (ignored) 5))
+           5)
+(test-comp '(call-with-escape-continuation (lambda (ignored) 5))
+           5)
+
+;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Check splitting of definitions
 (test-comp `(module m racket/base
               (define-values (x y) (values 1 2)))


### PR DESCRIPTION
Reduce `(call/cc (lambda (<ignored>) body ...))` to `(begin body ...)`.

I'm not sure about `call/ec`. I'm woried that `call/ec` may add some kind of prompt that may be visible.

This can be usefull for code like

    (let/ec exit
      (for ([i (in-range 1000)])
        (do-something-without-exit i)))

I have to increment `vclock` because it was necesary to avoid the move of some expressions like

    (let ([z (random)])
      (call/cc (lambda (ignored) z)))

to

    (let ([unused-z (random)])
      (random))

  