### PR TITLE
Fix make-contract example to show the correct contract violation

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/contracts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/contracts.scrbl
@@ -1979,7 +1979,7 @@ to determine if this is a contract that accepts only @racket[list?] values.
            (λ (x) (range (f (domain x))))
            (raise-blame-error
             b f
-            '(expected "a function of one argument" 'given: "~e")
+            '(expected "a function of one argument" given: "~e")
             f)))))))
 (contract int->int/c "not fun" 'positive 'negative)
 (define halve


### PR DESCRIPTION
There was a duplicate quote around `given:' which caused a violation in
make-contract's internals.