### PR TITLE
Remove obselete time config defines.

### DIFF
--- a/racket/src/racket/sconfig.h
+++ b/racket/src/racket/sconfig.h
@@ -37,7 +37,6 @@
 # define UNIX_FILE_SYSTEM
 # define NO_UNIX_USERS
 
-# define TIME_SYNTAX
 # define DIR_FUNCTION
 # define DIRENT_NO_NAMLEN
 # define GETENV_FUNCTION
@@ -648,7 +647,6 @@
 #  define MKDIR_NO_MODE_FLAG
 # endif
 
-# define TIME_SYNTAX
 # define USE_WIN32_TIME
 # define WINDOWS_GET_PROCESS_TIMES
 # define GETENV_FUNCTION
@@ -1043,18 +1041,12 @@
  /* Language Features */
 /*********************/
 
- /* TIME_SYNTAX adds the (time ...) syntax; this may need to be
-     turned off for compilation on some systems.
-    CLOCKS_PER_SEC relates the values returned by clock() to
+ /* CLOCKS_PER_SEC relates the values returned by clock() to
      real seconds. (The difference between two clock() calls is
      divided by this number.) Usually, this is defined in <time.h>;
      it defaults to 1000000 */
 
- /* USE_FTIME uses ftime instead of gettimeofday; only for TIME_SYNTAX */
-
- /* USE_PLAIN_TIME uses time; only for TIME_SYNTAX */
-
- /* USE_MACTIME uses the Mac toolbox to implement time functions. */
+ /* USE_PLAIN_TIME uses time. */
 
  /* USE_WIN32_TIME uses the Win32 API to implement time functions. */
 

--- a/racket/src/racket/src/schpriv.h
+++ b/racket/src/racket/src/schpriv.h
@@ -508,9 +508,7 @@ extern Scheme_Object *scheme_write_proc, *scheme_display_proc, *scheme_print_pro
 
 extern Scheme_Object *scheme_raise_arity_error_proc;
 
-#ifdef TIME_SYNTAX
 extern Scheme_Object *scheme_date;
-#endif
 
 extern Scheme_Object *scheme_liberal_def_ctx_type;
 

--- a/racket/src/racket/src/struct.c
+++ b/racket/src/racket/src/struct.c
@@ -249,11 +249,9 @@ scheme_init_struct (Scheme_Env *env)
   Scheme_Object **as_names;
   Scheme_Object **as_values;
   int as_count;
-#ifdef TIME_SYNTAX
   Scheme_Object **ts_names;
   Scheme_Object **ts_values;
   int ts_count;
-#endif
   Scheme_Object **loc_names;
   Scheme_Object **loc_values;
   int loc_count;
@@ -261,12 +259,10 @@ scheme_init_struct (Scheme_Env *env)
   Scheme_Object *guard;
 
   READ_ONLY static const char *arity_fields[1] = { "value" };
-#ifdef TIME_SYNTAX
   READ_ONLY static const char *date_fields[10] = { "second", "minute", "hour",
                                                    "day", "month", "year",
                                                    "week-day", "year-day", "dst?", "time-zone-offset" };
   READ_ONLY static const char *date_star_fields[2] = { "nanosecond", "time-zone-name" };
-#endif
   READ_ONLY static const char *location_fields[10] = { "source", "line", "column", "position", "span" };
   
 #ifdef MZ_PRECISE_GC
@@ -290,7 +286,6 @@ scheme_init_struct (Scheme_Env *env)
 			       env);
   }
 
-#ifdef TIME_SYNTAX
   /* Add date structure: */
   REGISTER_SO(scheme_date);
   scheme_date = scheme_make_struct_type_from_string("date", NULL, 10, NULL,
@@ -322,8 +317,6 @@ scheme_init_struct (Scheme_Env *env)
 			       env);
   }
   
-
-#endif
 
   /* Add location structure: */
   REGISTER_SO(location_struct);

--- a/racket/src/racket/uconfig.h
+++ b/racket/src/racket/uconfig.h
@@ -5,7 +5,6 @@
 #define SYSTEM_TYPE_NAME "unix"
 #define UNIX_FILE_SYSTEM
 
-#define TIME_SYNTAX
 #define PROCESS_FUNCTION
 #define DIR_FUNCTION
 #define GETENV_FUNCTION


### PR DESCRIPTION
Removes `USE_FTIME`, `USE_PALMTIME`, `USE_MACTIME`.