### PR TITLE
syntax/parse: fix disappeared-use property in attribute macro

### DIFF
--- a/racket/collects/syntax/parse/private/residual.rkt
+++ b/racket/collects/syntax/parse/private/residual.rkt
@@ -99,7 +99,7 @@
              (raise-syntax-error #f "not bound as an attribute" stx #'name))
            (syntax-property (attribute-mapping-var attr)
                             'disappeared-use
-                            #'name))))]))
+                            (list (syntax-local-introduce #'name))))))]))
 
 ;; (attribute-binding id)
 ;; mostly for debugging/testing


### PR DESCRIPTION
This fixes the DrRacket check syntax arrows in uses of `attribute` like this:
```racket
#lang racket/base
(require syntax/parse)
(syntax-parse #'a
  [a
   (attribute a)])
```